### PR TITLE
fix: Remove duplicate audioManager.stop() calls

### DIFF
--- a/Oak/Oak/ViewModels/FocusSessionViewModel.swift
+++ b/Oak/Oak/ViewModels/FocusSessionViewModel.swift
@@ -196,8 +196,7 @@ class FocusSessionViewModel: ObservableObject {
                 progressManager.recordSessionCompletion(durationMinutes: durationMinutes)
             }
         } else {
-            // Break session complete - stop audio
-            audioManager.stop()
+            // Break session complete
         }
 
         // Stop audio when any session ends


### PR DESCRIPTION
## Summary

- Removed duplicate `audioManager.stop()` call in `completeSession()`
- The unconditional call at the end of the method remains, ensuring audio stops for all session types
- Simplified control flow by eliminating dead code

Closes #2

## Test plan

- [x] All existing tests pass (36/36)
- [x] Build succeeds
- [x] Manual verification: Audio stops on both work and break session completion

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Remove duplicate `audioManager.stop()` call in `completeSession()` in `FocusSessionViewModel.swift`, simplifying control flow.
> 
>   - **Behavior**:
>     - Removed duplicate `audioManager.stop()` call in `completeSession()` in `FocusSessionViewModel.swift`.
>     - Ensures audio stops for all session types with a single call at the end of the method.
>   - **Misc**:
>     - Simplified control flow by removing dead code in `completeSession()`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=jellydn%2Foak&utm_source=github&utm_medium=referral)<sup> for f683f112dd5ae690595bedac02c784f8ca3329d5. You can [customize](https://app.ellipsis.dev/jellydn/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized audio management logic during session completion to reduce redundant audio stop calls, ensuring audio stops cleanly once at the end of each session.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->