### PR TITLE
feat(progress): add detailed session timeline view

### DIFF
--- a/Oak/Oak/Models/ProgressData.swift
+++ b/Oak/Oak/Models/ProgressData.swift
@@ -1,16 +1,53 @@
 import Foundation
 
+internal enum SessionType: String, Codable {
+    case work
+    case shortBreak
+    case longBreak
+}
+
+internal struct SessionRecord: Codable, Identifiable, Equatable {
+    let id: UUID
+    let type: SessionType
+    let startTime: Date
+    let endTime: Date
+    let durationMinutes: Int
+    
+    init(id: UUID = UUID(), type: SessionType, startTime: Date, endTime: Date, durationMinutes: Int) {
+        self.id = id
+        self.type = type
+        self.startTime = startTime
+        self.endTime = endTime
+        self.durationMinutes = durationMinutes
+    }
+}
+
 internal struct ProgressData: Codable, Identifiable {
     public let id: UUID
     let date: Date
     var focusMinutes: Int
     var completedSessions: Int
+    var sessions: [SessionRecord]
 
-    init(date: Date = Date(), focusMinutes: Int = 0, completedSessions: Int = 0) {
-        id = UUID()
+    init(date: Date = Date(), focusMinutes: Int = 0, completedSessions: Int = 0, sessions: [SessionRecord] = []) {
+        self.id = UUID()
         self.date = date
         self.focusMinutes = focusMinutes
         self.completedSessions = completedSessions
+        self.sessions = sessions
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case id, date, focusMinutes, completedSessions, sessions
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.id = try container.decodeIfPresent(UUID.self, forKey: .id) ?? UUID()
+        self.date = try container.decode(Date.self, forKey: .date)
+        self.focusMinutes = try container.decode(Int.self, forKey: .focusMinutes)
+        self.completedSessions = try container.decode(Int.self, forKey: .completedSessions)
+        self.sessions = try container.decodeIfPresent([SessionRecord].self, forKey: .sessions) ?? []
     }
 }
 
@@ -18,4 +55,5 @@ internal struct DailyStats {
     let todayFocusMinutes: Int
     let todayCompletedSessions: Int
     let streakDays: Int
+    let todaySessions: [SessionRecord]
 }

--- a/Oak/Oak/Services/ProgressManager.swift
+++ b/Oak/Oak/Services/ProgressManager.swift
@@ -2,7 +2,12 @@ import Foundation
 
 @MainActor
 internal class ProgressManager: ObservableObject {
-    @Published var dailyStats = DailyStats(todayFocusMinutes: 0, todayCompletedSessions: 0, streakDays: 0)
+    @Published var dailyStats = DailyStats(
+        todayFocusMinutes: 0,
+        todayCompletedSessions: 0,
+        streakDays: 0,
+        todaySessions: []
+    )
 
     private let userDefaults: UserDefaults
     private let progressKey = "progressHistory"
@@ -40,16 +45,36 @@ internal class ProgressManager: ObservableObject {
         return false
     }
 
-    func recordSessionCompletion(durationMinutes: Int) {
+    func recordSessionCompletion(
+        durationMinutes: Int,
+        type: SessionType = .work,
+        startTime: Date = Date(),
+        endTime: Date = Date()
+    ) {
         let didChangeDay = checkDayChange()
         var records = loadRecords()
         let today = Calendar.current.startOfDay(for: Date())
+        let newSession = SessionRecord(
+            type: type,
+            startTime: startTime,
+            endTime: endTime,
+            durationMinutes: durationMinutes
+        )
 
         if let index = records.firstIndex(where: { Calendar.current.isDate($0.date, inSameDayAs: today) }) {
             records[index].focusMinutes += durationMinutes
-            records[index].completedSessions += 1
+            if type == .work {
+                records[index].completedSessions += 1
+            }
+            records[index].sessions.append(newSession)
         } else {
-            let newRecord = ProgressData(date: today, focusMinutes: durationMinutes, completedSessions: 1)
+            let completedSessions = type == .work ? 1 : 0
+            let newRecord = ProgressData(
+                date: today,
+                focusMinutes: durationMinutes,
+                completedSessions: completedSessions,
+                sessions: [newSession]
+            )
             records.append(newRecord)
         }
 
@@ -92,11 +117,13 @@ internal class ProgressManager: ObservableObject {
         let todayFocusMinutes = todayRecord?.focusMinutes ?? 0
         let todayCompletedSessions = todayRecord?.completedSessions ?? 0
         let streakDays = calculateStreak(records: records)
+        let todaySessions = todayRecord?.sessions ?? []
 
         dailyStats = DailyStats(
             todayFocusMinutes: todayFocusMinutes,
             todayCompletedSessions: todayCompletedSessions,
-            streakDays: streakDays
+            streakDays: streakDays,
+            todaySessions: todaySessions
         )
     }
 

--- a/Oak/Oak/Services/ProgressManager.swift
+++ b/Oak/Oak/Services/ProgressManager.swift
@@ -62,17 +62,16 @@ internal class ProgressManager: ObservableObject {
         )
 
         if let index = records.firstIndex(where: { Calendar.current.isDate($0.date, inSameDayAs: today) }) {
-            records[index].focusMinutes += durationMinutes
             if type == .work {
+                records[index].focusMinutes += durationMinutes
                 records[index].completedSessions += 1
             }
             records[index].sessions.append(newSession)
         } else {
-            let completedSessions = type == .work ? 1 : 0
             let newRecord = ProgressData(
                 date: today,
-                focusMinutes: durationMinutes,
-                completedSessions: completedSessions,
+                focusMinutes: type == .work ? durationMinutes : 0,
+                completedSessions: type == .work ? 1 : 0,
                 sessions: [newSession]
             )
             records.append(newRecord)

--- a/Oak/Oak/ViewModels/FocusSessionViewModel.swift
+++ b/Oak/Oak/ViewModels/FocusSessionViewModel.swift
@@ -28,6 +28,7 @@ internal class FocusSessionViewModel: ObservableObject {
     private var isLongBreak: Bool = false
     private var sessionStartSeconds: Int = 0
     private var sessionEndDate: Date?
+    private var currentSessionStartTime: Date?
     private var presetSettingsCancellable: AnyCancellable?
     private var lastPlayingAudioTrack: AudioTrack = .none
     private var wasAutoStarted: Bool = false
@@ -159,6 +160,10 @@ internal class FocusSessionViewModel: ObservableObject {
         progressManager.dailyStats.streakDays
     }
 
+    var todaySessions: [SessionRecord] {
+        progressManager.dailyStats.todaySessions
+    }
+
     func cleanup() {
         resetSession()
     }
@@ -191,6 +196,7 @@ internal extension FocusSessionViewModel {
         isWorkSession = true
         isLongBreak = false
         sessionStartSeconds = currentRemainingSeconds
+        currentSessionStartTime = Date()
         completedRounds = 0
         sessionState = .running(remainingSeconds: currentRemainingSeconds, isWorkSession: isWorkSession)
         startTimer()
@@ -239,6 +245,7 @@ internal extension FocusSessionViewModel {
         }
 
         sessionStartSeconds = currentRemainingSeconds
+        currentSessionStartTime = Date()
         sessionState = .running(remainingSeconds: currentRemainingSeconds, isWorkSession: isWorkSession)
 
         if isWorkSession && lastPlayingAudioTrack != .none {
@@ -258,6 +265,7 @@ internal extension FocusSessionViewModel {
         isLongBreak = false
         sessionStartSeconds = 0
         sessionEndDate = nil
+        currentSessionStartTime = nil
         isSessionComplete = false
         completedRounds = 0
         autoStartCountdown = 0
@@ -292,16 +300,25 @@ internal extension FocusSessionViewModel {
     }
 
     func completeSession() {
+        let sessionType: SessionType
         if isWorkSession {
-            let durationMinutes = (sessionStartSeconds - currentRemainingSeconds) / 60
-            if durationMinutes > 0 {
-                progressManager.recordSessionCompletion(durationMinutes: durationMinutes)
-            }
+            sessionType = .work
             completedRounds += 1
         } else {
+            sessionType = isLongBreak ? .longBreak : .shortBreak
             if isLongBreak {
                 completedRounds = 0
             }
+        }
+
+        let durationMinutes = (sessionStartSeconds - currentRemainingSeconds) / 60
+        if durationMinutes > 0, let startTime = currentSessionStartTime {
+            progressManager.recordSessionCompletion(
+                durationMinutes: durationMinutes,
+                type: sessionType,
+                startTime: startTime,
+                endTime: Date()
+            )
         }
 
         notificationService.sendSessionCompletionNotification(isWorkSession: isWorkSession)

--- a/Oak/Oak/Views/ProgressMenuView.swift
+++ b/Oak/Oak/Views/ProgressMenuView.swift
@@ -63,8 +63,77 @@ internal struct ProgressMenuView: View {
             }
             .padding(.horizontal, 8)
 
-            Spacer()
+            if !viewModel.todaySessions.isEmpty {
+                Divider()
+                    .padding(.vertical, 8)
+
+                VStack(alignment: .leading, spacing: 8) {
+                    Text("Timeline")
+                        .font(.subheadline)
+                        .fontWeight(.semibold)
+                        .foregroundColor(.secondary)
+                        .padding(.horizontal, 8)
+
+                    ScrollView {
+                        VStack(spacing: 12) {
+                            ForEach(viewModel.todaySessions.sorted { $0.startTime > $1.startTime }) { session in
+                                HStack(spacing: 12) {
+                                    Circle()
+                                        .fill(colorForSessionType(session.type))
+                                        .frame(width: 8, height: 8)
+
+                                    VStack(alignment: .leading, spacing: 2) {
+                                        Text(titleForSessionType(session.type))
+                                            .font(.subheadline)
+                                            .fontWeight(.medium)
+                                        Text(timeRangeString(start: session.startTime, end: session.endTime))
+                                            .font(.caption2)
+                                            .foregroundColor(.secondary)
+                                    }
+
+                                    Spacer()
+
+                                    Text("\(session.durationMinutes)m")
+                                        .font(.caption)
+                                        .foregroundColor(.secondary)
+                                }
+                                .padding(.horizontal, 8)
+                                .padding(.vertical, 4)
+                                .background(Color.secondary.opacity(0.1))
+                                .cornerRadius(8)
+                            }
+                        }
+                        .padding(.horizontal, 8)
+                        .padding(.bottom, 8)
+                    }
+                    .frame(maxHeight: 200)
+                }
+            } else {
+                Spacer()
+            }
         }
         .padding()
+    }
+
+    private func colorForSessionType(_ type: SessionType) -> Color {
+        switch type {
+        case .work: return .blue
+        case .shortBreak: return .green
+        case .longBreak: return .orange
+        }
+    }
+
+    private func titleForSessionType(_ type: SessionType) -> String {
+        switch type {
+        case .work: return "Focus"
+        case .shortBreak: return "Short Break"
+        case .longBreak: return "Long Break"
+        }
+    }
+
+    private func timeRangeString(start: Date, end: Date) -> String {
+        let formatter = DateFormatter()
+        formatter.timeStyle = .short
+        return "\(formatter.string(from: start)) - \(formatter.string(from: end))"
     }
 }

--- a/Oak/Tests/OakTests/MockAudioManager.swift
+++ b/Oak/Tests/OakTests/MockAudioManager.swift
@@ -4,7 +4,7 @@ import AVFoundation
 @MainActor
 internal final class MockAudioManager: AudioManager {
     init() {
-        super.init(audioEngineFactory: { MockTestAudioEngine() })
+        super.init { MockTestAudioEngine() }
     }
 
     override func play(track: AudioTrack) {


### PR DESCRIPTION
### What
Added a detailed timeline view to the Progress Menu that shows exactly when focus sessions and breaks occurred throughout the day.

### Why
Users want more detailed information about what happened during their day, rather than just seeing total focus minutes and completed sessions.

### How
- Updated `ProgressData` to store an array of `SessionRecord` objects containing start/end times and session type.
- Updated `ProgressManager` and `FocusSessionViewModel` to capture timestamps and session types and log them.
- Updated `ProgressMenuView` to display a `ScrollView` timeline with color-coded entries for Work, Short Break, and Long Break sessions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a session timeline view displaying today's completed sessions with type (work/break), duration, and time range.
  * Enhanced session tracking to record all session types with precise start and end time information.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jellydn/oak/pull/113?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->