### PR TITLE
docs: document session timeline feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ In today's world of constant distractions, deep work has become increasingly rar
 - ▶️ **Session controls**: Start, pause, and resume your focus sessions
 - 🎵 **Ambient sounds**: Rain, forest, cafe, brown noise, and lo-fi to help you concentrate
 - 📊 **Local tracking**: Track daily focus minutes, completed sessions, and 7-day streaks
+- 🕒 **Session timeline**: See each focus session and break from today with start/end times and durations
 - 🔄 **Auto-update**: Seamless updates via Sparkle framework
 
 ## Installation

--- a/docs/index.html
+++ b/docs/index.html
@@ -523,6 +523,10 @@ brew install --cask oak</code></pre>
                     <h3>Local progress tracking</h3>
                     <p>Track daily focus minutes, completed sessions, and 7-day streaks entirely on-device.</p>
                 </article>
+                <article class="card">
+                    <h3>Session timeline</h3>
+                    <p>Review today's focus and break sessions with start/end times and durations from the progress menu.</p>
+                </article>
             </div>
         </section>
 


### PR DESCRIPTION
Documents the detailed session timeline view added in #114.

## Changes

- **README.md** — Added `🕒 Session timeline` bullet to the Features list
- **docs/index.html** — Added a 'Session timeline' card to the landing page Features grid

## Triggered by

- ae1f5b6 `feat(progress): add detailed session timeline view (#114)` — Adds the Timeline section in the Progress menu (Focus / Short Break / Long Break entries with start/end times and durations)

## Notes

Strictly additive — no existing copy was modified. Streak-on-break-only-days fix included in #114 is internal behavior with no prior documentation, so no doc change is needed for it.

Please review for accuracy and tone alignment with existing copy.

🤖 Generated via the `docs-update` skill.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated project documentation to include the Session timeline feature, which displays each focus session and break with start/end times and durations accessible from the progress menu.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jellydn/oak/pull/115?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->