### PR TITLE
refactor(session): introduce SessionEngine as functional core (phase 1)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -100,3 +100,19 @@ Expansion is triggered by a toggle click. Auto-collapse occurs after an idle tim
 ## Always On Top
 
 A window-level behavior that keeps the notch panel above all other application windows. Configurable on/off. Default: **on**.
+
+## Session Engine
+
+The pure finite-state machine that owns Focus Session lifecycle, Round tracking, Long Break decisions, and audio-resume memory. It accepts **Session Events** and emits **Session Intents** describing the side effects the shell should perform. The Session Engine has no Foundation side effects of its own — no timers, no audio, no notifications, no persistence. See [ADR-0004](doc/adr/0004-session-engine-as-functional-core.md).
+
+## Session Event
+
+An input to the Session Engine: `start`, `pause`, `resume`, `tick`, `startNext`, `reset`. Every event carries `now: Date` so the engine is fully driven by an explicit clock.
+
+## Session Intent
+
+A side-effect command emitted by the Session Engine for the shell to execute: record a completion, stop/pause/resume audio, start the remembered audio track, notify the user, play the completion sound, flash the completion state, schedule the auto-start countdown.
+
+## Session Config
+
+The subset of preferences the Session Engine reads — Focus / Break / Long-Break durations, Rounds Before Long Break, completion-sound flags, and the auto-start flag. Snapshotted from `PresetSettingsStore` by the shell and pushed into the engine via `updateConfig(_:)`.

--- a/Oak/Oak.xcodeproj/project.pbxproj
+++ b/Oak/Oak.xcodeproj/project.pbxproj
@@ -28,12 +28,14 @@
 		4A698BFDAA1F8E649D836ACF /* NotchCompanionView+Controls.swift in Sources */ = {isa = PBXBuildFile; fileRef = B452D0B99FA21480DB4AD6A5 /* NotchCompanionView+Controls.swift */; };
 		4B5B7AD41E542963653F229A /* NotchWindowControllerTests+WindowBehavior.swift in Sources */ = {isa = PBXBuildFile; fileRef = 814659335F8FBC1EB95296FD /* NotchWindowControllerTests+WindowBehavior.swift */; };
 		4D92A0354DDAC317E9E44D17 /* LongBreakTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83E7ADCEF210103CF3189D41 /* LongBreakTests.swift */; };
+		4EBF5F1B6623FFAF8B473FF2 /* SessionIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 225699F89473B0C186B6BC28 /* SessionIntent.swift */; };
 		542154C3442D3F88977C493D /* ClickOutsideModifierTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E813C6E3CE44E2E0F36F640 /* ClickOutsideModifierTests.swift */; };
 		5ACFC4E7023A7CB22C98EDD3 /* NSScreen+DisplayTarget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C90E7594FA40128ADA5F39F /* NSScreen+DisplayTarget.swift */; };
 		610C05D4C9C49C70A78B7D69 /* README.md in Resources */ = {isa = PBXBuildFile; fileRef = B1EB99EC9EF014772EA562EF /* README.md */; };
 		61F4A962C9C52E757FAE25FE /* ambient_brown_noise.m4a in Resources */ = {isa = PBXBuildFile; fileRef = 7663A82B3FFE2837587C2B2F /* ambient_brown_noise.m4a */; };
 		67136E958CB86E30F7443B8B /* NSScreen+UUID.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC19349D6F25778FBE54A06F /* NSScreen+UUID.swift */; };
 		6BF9354EE28ABB4B59A9E051 /* Sparkle in Frameworks */ = {isa = PBXBuildFile; productRef = B28E445B82B7BC8D6C4D0984 /* Sparkle */; };
+		6E8CFFB1ABA49356E13D965D /* SessionEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 419B61F241E46CA974CBC281 /* SessionEvent.swift */; };
 		716599FCD65FC35919E253E8 /* SettingsMenuView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23364F4B016E445E5657BF63 /* SettingsMenuView.swift */; };
 		81C83510720895955C3CAF42 /* AutoStartNextIntervalTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CC50430910EB73FAE1074FE /* AutoStartNextIntervalTests.swift */; };
 		82C6E45CC0A2D94BBBB83623 /* CountdownDisplayMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = A53A901D48495497B38B2A1E /* CountdownDisplayMode.swift */; };
@@ -56,6 +58,7 @@
 		B54A841D1308C18C226BF1C0 /* US003Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85C93F37E0AC4AA71C304FDD /* US003Tests.swift */; };
 		B561D0C04BC57500AF7A7EF0 /* NotchLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 164FAFB05B901C05BD1479BF /* NotchLayout.swift */; };
 		B5C9AD5FC22FACC36FAA5620 /* AudioMenuView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3D8E840983307E12ADC1FCF /* AudioMenuView.swift */; };
+		B5DFE50C400C98CC4F80A52F /* SessionEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A4F7ABA84B024AAEF305534 /* SessionEngine.swift */; };
 		B961DAB61BE6B064D46152D3 /* NotchCompanionView+StandardViews.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E581D2529EA9F9B22AEB5DE /* NotchCompanionView+StandardViews.swift */; };
 		B9FD45AD05705636C1173EAC /* NotchWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DE8639CEB8A5AB873283533 /* NotchWindowController.swift */; };
 		BC0152F64748D50B856DA0C1 /* ambient_forest.m4a in Resources */ = {isa = PBXBuildFile; fileRef = 7D93E5502BBC8DD90FD136BB /* ambient_forest.m4a */; };
@@ -66,7 +69,9 @@
 		D9BC1320EE869D9AD7FE40AE /* SparkleUpdater.swift in Sources */ = {isa = PBXBuildFile; fileRef = 770CCC886CF6A5E903159704 /* SparkleUpdater.swift */; };
 		DD867AD4D9ABF04F13068B20 /* US002Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26934C0C6B7C8A90F9D57916 /* US002Tests.swift */; };
 		DDBB5DE34EE0CD19E4F5DB8C /* NotificationSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2248B235C4F98DAE862335B3 /* NotificationSettingsView.swift */; };
+		DF0970D1879A087936D99596 /* SessionEngineTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDAEE0A95005BB01B28662F9 /* SessionEngineTests.swift */; };
 		DF1ECF04DC3D712A1F7B0C30 /* NotificationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98D555E4182E199E8EC8D0B3 /* NotificationService.swift */; };
+		E3B4BF5FB412A3CA164C55F9 /* SessionConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = F267103CDBA4F34B273D47CE /* SessionConfig.swift */; };
 		E3BAB7635E9F5CEAABADB263 /* ProgressManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EFD132B19656D2C6D2CA981 /* ProgressManager.swift */; };
 		EBE81F10378684B523C9D931 /* CountdownDisplayModeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F294622BEE001AE06968C35C /* CountdownDisplayModeTests.swift */; };
 		EC877E270C24B19E01A1DDE4 /* ConfettiViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14E1129CEDF63355578B0485 /* ConfettiViewTests.swift */; };
@@ -92,6 +97,7 @@
 		0679D26521D6F4E9C5774630 /* NotchCompanionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotchCompanionView.swift; sourceTree = "<group>"; };
 		0759FB9C079ECAE57D72A839 /* AlwaysOnTopTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlwaysOnTopTests.swift; sourceTree = "<group>"; };
 		08E0A4A56EADCDB21276DE81 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		0A4F7ABA84B024AAEF305534 /* SessionEngine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionEngine.swift; sourceTree = "<group>"; };
 		0E00D04EC9E5E33BBF5D09F7 /* SmokeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SmokeTests.swift; sourceTree = "<group>"; };
 		0E813C6E3CE44E2E0F36F640 /* ClickOutsideModifierTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClickOutsideModifierTests.swift; sourceTree = "<group>"; };
 		1049365D0D64C5E5471825BD /* NSScreenNotchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NSScreenNotchTests.swift; sourceTree = "<group>"; };
@@ -103,6 +109,7 @@
 		1CDDE42AD58F6B067B64ED90 /* ProgressData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProgressData.swift; sourceTree = "<group>"; };
 		1E53FB903AF7AF6B4DE091AD /* AccessibilityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccessibilityTests.swift; sourceTree = "<group>"; };
 		2248B235C4F98DAE862335B3 /* NotificationSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationSettingsView.swift; sourceTree = "<group>"; };
+		225699F89473B0C186B6BC28 /* SessionIntent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionIntent.swift; sourceTree = "<group>"; };
 		22F9A4FB15C8C324972DB6D6 /* NotchWindowControllerTests+NotchWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NotchWindowControllerTests+NotchWindow.swift"; sourceTree = "<group>"; };
 		2323FD43612DC128B03544D4 /* NotchCompanionViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotchCompanionViewTests.swift; sourceTree = "<group>"; };
 		23364F4B016E445E5657BF63 /* SettingsMenuView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsMenuView.swift; sourceTree = "<group>"; };
@@ -116,6 +123,7 @@
 		3CC50430910EB73FAE1074FE /* AutoStartNextIntervalTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoStartNextIntervalTests.swift; sourceTree = "<group>"; };
 		3DCAC7004FB57BBA5CEBB9B3 /* NotchVisualStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotchVisualStyle.swift; sourceTree = "<group>"; };
 		3DE8639CEB8A5AB873283533 /* NotchWindowController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotchWindowController.swift; sourceTree = "<group>"; };
+		419B61F241E46CA974CBC281 /* SessionEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionEvent.swift; sourceTree = "<group>"; };
 		451C36F9BC7A6103BF32362C /* OakApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OakApp.swift; sourceTree = "<group>"; };
 		53877747FE72F8926A70A9E0 /* FocusSessionViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FocusSessionViewModel.swift; sourceTree = "<group>"; };
 		5B1E09A351763DC5E48FA361 /* AudioManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioManagerTests.swift; sourceTree = "<group>"; };
@@ -153,6 +161,8 @@
 		DCB9EFBE035ED14BBCAAD3D9 /* NotchCompanionViewTests+SessionState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NotchCompanionViewTests+SessionState.swift"; sourceTree = "<group>"; };
 		E43285E82910BB45D9CF9000 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		E680D8D9839B944EB6CB5723 /* NotchWindowControllerTests+NotchFirstUI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NotchWindowControllerTests+NotchFirstUI.swift"; sourceTree = "<group>"; };
+		EDAEE0A95005BB01B28662F9 /* SessionEngineTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionEngineTests.swift; sourceTree = "<group>"; };
+		F267103CDBA4F34B273D47CE /* SessionConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionConfig.swift; sourceTree = "<group>"; };
 		F287A617D7BF92425C7BD22A /* ConfettiView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfettiView.swift; sourceTree = "<group>"; };
 		F294622BEE001AE06968C35C /* CountdownDisplayModeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CountdownDisplayModeTests.swift; sourceTree = "<group>"; };
 		F3D8E840983307E12ADC1FCF /* AudioMenuView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioMenuView.swift; sourceTree = "<group>"; };
@@ -177,6 +187,10 @@
 				A53A901D48495497B38B2A1E /* CountdownDisplayMode.swift */,
 				164FAFB05B901C05BD1479BF /* NotchLayout.swift */,
 				1CDDE42AD58F6B067B64ED90 /* ProgressData.swift */,
+				F267103CDBA4F34B273D47CE /* SessionConfig.swift */,
+				0A4F7ABA84B024AAEF305534 /* SessionEngine.swift */,
+				419B61F241E46CA974CBC281 /* SessionEvent.swift */,
+				225699F89473B0C186B6BC28 /* SessionIntent.swift */,
 				23F2FC6738FCAE0999D42A11 /* SessionModels.swift */,
 			);
 			path = Models;
@@ -257,6 +271,7 @@
 				3912FED25041D62DE77347EA /* NotificationTests.swift */,
 				1049365D0D64C5E5471825BD /* NSScreenNotchTests.swift */,
 				131CDA9D17A7D22CBC67785C /* SessionCompletionNotificationTests.swift */,
+				EDAEE0A95005BB01B28662F9 /* SessionEngineTests.swift */,
 				0E00D04EC9E5E33BBF5D09F7 /* SmokeTests.swift */,
 				B678070C4468D7AD6171B2C2 /* SparkleUpdaterTests.swift */,
 				B74BB88C04B3824E97E3C561 /* US001Tests.swift */,
@@ -448,6 +463,10 @@
 				16AB818C370C3132420E8C87 /* ProgressData.swift in Sources */,
 				E3BAB7635E9F5CEAABADB263 /* ProgressManager.swift in Sources */,
 				C1C2CDACE52EEF5146C83881 /* ProgressMenuView.swift in Sources */,
+				E3B4BF5FB412A3CA164C55F9 /* SessionConfig.swift in Sources */,
+				B5DFE50C400C98CC4F80A52F /* SessionEngine.swift in Sources */,
+				6E8CFFB1ABA49356E13D965D /* SessionEvent.swift in Sources */,
+				4EBF5F1B6623FFAF8B473FF2 /* SessionIntent.swift in Sources */,
 				CE3A4934C57D1C203D016F96 /* SessionModels.swift in Sources */,
 				716599FCD65FC35919E253E8 /* SettingsMenuView.swift in Sources */,
 				D9BC1320EE869D9AD7FE40AE /* SparkleUpdater.swift in Sources */,
@@ -482,6 +501,7 @@
 				AC7D0BE9D2A43B9602F5FFA9 /* NotchWindowControllerTests.swift in Sources */,
 				25BAA3E90290CE446B9F7BFC /* NotificationTests.swift in Sources */,
 				F32ECEC3C32292DC1969C472 /* SessionCompletionNotificationTests.swift in Sources */,
+				DF0970D1879A087936D99596 /* SessionEngineTests.swift in Sources */,
 				98EA03D50041483DEFBB6984 /* SmokeTests.swift in Sources */,
 				088CE53BA008F2E0ED7225E3 /* SparkleUpdaterTests.swift in Sources */,
 				1B420ABE27C55D4F4D474075 /* US001Tests.swift in Sources */,
@@ -643,14 +663,14 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 5027;
+				CURRENT_PROJECT_VERSION = 5031;
 				INFOPLIST_FILE = Oak/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 13.0;
-				MARKETING_VERSION = 0.5.27;
+				MARKETING_VERSION = 0.5.31;
 				PRODUCT_BUNDLE_IDENTIFIER = com.productsway.oak.app;
 				SDKROOT = macosx;
 				SPARKLE_PUBLIC_ED_KEY = "IjFqN1R6i4Dh8IZxQ42RtSEii7pUgS45+NvidSwQup0=";
@@ -679,14 +699,14 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 5027;
+				CURRENT_PROJECT_VERSION = 5031;
 				INFOPLIST_FILE = Oak/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 13.0;
-				MARKETING_VERSION = 0.5.27;
+				MARKETING_VERSION = 0.5.31;
 				PRODUCT_BUNDLE_IDENTIFIER = com.productsway.oak.app;
 				SDKROOT = macosx;
 				SPARKLE_PUBLIC_ED_KEY = "IjFqN1R6i4Dh8IZxQ42RtSEii7pUgS45+NvidSwQup0=";

--- a/Oak/Oak/Models/SessionConfig.swift
+++ b/Oak/Oak/Models/SessionConfig.swift
@@ -1,0 +1,16 @@
+import Foundation
+
+/// Configuration snapshot consumed by `SessionEngine`.
+///
+/// The shell builds this from `PresetSettingsStore` for the currently
+/// selected `Preset` and pushes updates via `SessionEngine.updateConfig(_:)`
+/// whenever preferences change.
+internal struct SessionConfig: Equatable {
+    let workSeconds: Int
+    let breakSeconds: Int
+    let longBreakSeconds: Int
+    let roundsBeforeLongBreak: Int
+    let playSoundOnSessionCompletion: Bool
+    let playSoundOnBreakCompletion: Bool
+    let autoStartNextInterval: Bool
+}

--- a/Oak/Oak/Models/SessionEngine.swift
+++ b/Oak/Oak/Models/SessionEngine.swift
@@ -1,0 +1,245 @@
+import Foundation
+
+/// Pure finite-state machine that owns Focus Session lifecycle, Round
+/// tracking, Long Break decisions, and audio-resume memory.
+///
+/// The engine performs no side effects of its own. Every `apply(_:)` returns
+/// an ordered array of `SessionIntent` describing what the shell should do.
+///
+/// Time is pushed in per event (`now: Date`). The injected `Calendar`
+/// determines day-rollover for round resets.
+///
+/// See [doc/adr/0004-session-engine-as-functional-core.md](../../../doc/adr/0004-session-engine-as-functional-core.md).
+internal struct SessionEngine {
+    // MARK: - Observable state
+
+    private(set) var state: SessionState = .idle
+    private(set) var completedRounds: Int = 0
+
+    // MARK: - Internal state
+
+    private var config: SessionConfig
+    private let calendar: Calendar
+    private var roundTrackingDate: Date
+
+    private var sessionStartSeconds: Int = 0
+    private var currentRemainingSeconds: Int = 0
+    private var sessionStartTime: Date?
+    private var sessionEndDate: Date?
+    private var wasAutoStarted: Bool = false
+
+    private var currentlyPlaying: AudioTrack = .none
+    private var lastPlayingAudioTrack: AudioTrack = .none
+
+    // MARK: - Init
+
+    init(config: SessionConfig, calendar: Calendar = .current, now: Date) {
+        self.config = config
+        self.calendar = calendar
+        roundTrackingDate = calendar.startOfDay(for: now)
+    }
+
+    // MARK: - Shell synchronisation (non-events)
+
+    mutating func updateConfig(_ new: SessionConfig) {
+        config = new
+    }
+
+    mutating func setCurrentlyPlayingAudio(_ track: AudioTrack) {
+        currentlyPlaying = track
+    }
+
+    // MARK: - Derived
+
+    /// If we are in `.completed`, what kind of session would `.startNext`
+    /// begin right now, given current `completedRounds` and `config`?
+    var nextSessionPreview: SessionType? {
+        guard case let .completed(kind) = state else { return nil }
+        switch kind {
+        case .work:
+            return shouldUseLongBreak ? .longBreak : .shortBreak
+        case .shortBreak, .longBreak:
+            return .work
+        }
+    }
+
+    // MARK: - Event dispatch
+
+    @discardableResult
+    mutating func apply(_ event: SessionEvent) -> [SessionIntent] {
+        switch event {
+        case let .start(now):
+            handleStart(now: now)
+        case let .pause(now):
+            handlePause(now: now)
+        case let .resume(now):
+            handleResume(now: now)
+        case let .tick(now):
+            handleTick(now: now)
+        case let .startNext(now, isAutoStart):
+            handleStartNext(now: now, isAutoStart: isAutoStart)
+        case .reset:
+            handleReset()
+        }
+    }
+
+    // MARK: - Event handlers
+
+    private mutating func handleStart(now: Date) -> [SessionIntent] {
+        guard case .idle = state else { return [] }
+        resetCompletedRoundsIfNeeded(now: now)
+        completedRounds = 0
+        wasAutoStarted = false
+        beginSession(kind: .work, durationSeconds: config.workSeconds, now: now)
+        return []
+    }
+
+    private mutating func handlePause(now: Date) -> [SessionIntent] {
+        guard case let .running(remaining, kind) = state else { return [] }
+        currentRemainingSeconds = remaining
+        sessionEndDate = nil
+        state = .paused(remainingSeconds: remaining, kind: kind)
+        _ = now
+        return [.pauseAudio]
+    }
+
+    private mutating func handleResume(now: Date) -> [SessionIntent] {
+        guard case let .paused(remaining, kind) = state else { return [] }
+        currentRemainingSeconds = remaining
+        sessionEndDate = now.addingTimeInterval(TimeInterval(remaining))
+        state = .running(remainingSeconds: remaining, kind: kind)
+        return [.resumePausedAudio]
+    }
+
+    private mutating func handleTick(now: Date) -> [SessionIntent] {
+        guard case let .running(_, kind) = state,
+              let endDate = sessionEndDate
+        else {
+            return []
+        }
+        let remaining = max(0, Int(ceil(endDate.timeIntervalSince(now))))
+        currentRemainingSeconds = remaining
+
+        if remaining <= 0 {
+            return completeSession(kind: kind, now: now)
+        } else {
+            state = .running(remainingSeconds: remaining, kind: kind)
+            return []
+        }
+    }
+
+    private mutating func handleStartNext(now: Date, isAutoStart: Bool) -> [SessionIntent] {
+        guard case let .completed(completedKind) = state else { return [] }
+        resetCompletedRoundsIfNeeded(now: now)
+        wasAutoStarted = isAutoStart
+
+        let nextKind: SessionType
+        let nextSeconds: Int
+        switch completedKind {
+        case .work:
+            if shouldUseLongBreak {
+                nextKind = .longBreak
+                nextSeconds = config.longBreakSeconds
+            } else {
+                nextKind = .shortBreak
+                nextSeconds = config.breakSeconds
+            }
+        case .shortBreak, .longBreak:
+            nextKind = .work
+            nextSeconds = config.workSeconds
+        }
+
+        beginSession(kind: nextKind, durationSeconds: nextSeconds, now: now)
+
+        if nextKind == .work, lastPlayingAudioTrack != .none {
+            return [.startRememberedAudio(track: lastPlayingAudioTrack)]
+        }
+        return []
+    }
+
+    private mutating func handleReset() -> [SessionIntent] {
+        currentRemainingSeconds = 0
+        sessionStartSeconds = 0
+        sessionEndDate = nil
+        sessionStartTime = nil
+        completedRounds = 0
+        wasAutoStarted = false
+        lastPlayingAudioTrack = .none
+        state = .idle
+        return [.stopAudio]
+    }
+
+    // MARK: - Helpers
+
+    private mutating func beginSession(kind: SessionType, durationSeconds: Int, now: Date) {
+        currentRemainingSeconds = durationSeconds
+        sessionStartSeconds = durationSeconds
+        sessionStartTime = now
+        sessionEndDate = now.addingTimeInterval(TimeInterval(durationSeconds))
+        state = .running(remainingSeconds: durationSeconds, kind: kind)
+    }
+
+    private mutating func completeSession(kind: SessionType, now: Date) -> [SessionIntent] {
+        resetCompletedRoundsIfNeeded(now: now)
+        var intents: [SessionIntent] = []
+
+        switch kind {
+        case .work:
+            completedRounds += 1
+        case .longBreak:
+            completedRounds = 0
+        case .shortBreak:
+            break
+        }
+
+        let durationMinutes = (sessionStartSeconds - currentRemainingSeconds) / 60
+        if durationMinutes > 0, let startTime = sessionStartTime {
+            let record = SessionRecord(
+                type: kind,
+                startTime: startTime,
+                endTime: now,
+                durationMinutes: durationMinutes
+            )
+            intents.append(.recordCompletion(record))
+        }
+
+        intents.append(.notifyCompleted(kind: kind))
+
+        if currentlyPlaying != .none {
+            lastPlayingAudioTrack = currentlyPlaying
+        }
+        intents.append(.stopAudio)
+
+        let shouldPlaySound: Bool = if kind == .work {
+            config.playSoundOnSessionCompletion
+        } else {
+            config.playSoundOnBreakCompletion && !wasAutoStarted
+        }
+        if shouldPlaySound {
+            intents.append(.playCompletionSound)
+        }
+
+        intents.append(.flashCompletion)
+
+        if config.autoStartNextInterval {
+            intents.append(.scheduleAutoStartCountdown)
+        }
+
+        sessionEndDate = nil
+        state = .completed(kind: kind)
+        return intents
+    }
+
+    private var shouldUseLongBreak: Bool {
+        completedRounds >= config.roundsBeforeLongBreak
+    }
+
+    private mutating func resetCompletedRoundsIfNeeded(now: Date) {
+        let today = calendar.startOfDay(for: now)
+        guard !calendar.isDate(roundTrackingDate, inSameDayAs: today) else {
+            return
+        }
+        roundTrackingDate = today
+        completedRounds = 0
+    }
+}

--- a/Oak/Oak/Models/SessionEvent.swift
+++ b/Oak/Oak/Models/SessionEvent.swift
@@ -1,0 +1,14 @@
+import Foundation
+
+/// Input event applied to `SessionEngine`.
+///
+/// Every event carries `now: Date` so the engine is fully driven by an
+/// explicit clock — tests advance time by passing different values.
+internal enum SessionEvent: Equatable {
+    case start(now: Date)
+    case pause(now: Date)
+    case resume(now: Date)
+    case tick(now: Date)
+    case startNext(now: Date, isAutoStart: Bool)
+    case reset
+}

--- a/Oak/Oak/Models/SessionIntent.swift
+++ b/Oak/Oak/Models/SessionIntent.swift
@@ -1,0 +1,35 @@
+import Foundation
+
+/// Side-effect command emitted by `SessionEngine` for the shell to execute.
+///
+/// The engine itself never performs side effects; the shell switches over
+/// intents to drive `AudioManager`, `NotificationService`, `ProgressManager`,
+/// and view-layer animation state.
+internal enum SessionIntent: Equatable {
+    /// Persist a completed session to the progress history.
+    case recordCompletion(SessionRecord)
+
+    /// Stop ambient audio entirely (e.g. on session completion or reset).
+    case stopAudio
+
+    /// Pause audio without forgetting the current track (on session pause).
+    case pauseAudio
+
+    /// Resume audio that was previously paused (on session resume).
+    case resumePausedAudio
+
+    /// Start the remembered track when a new work session begins after a break.
+    case startRememberedAudio(track: AudioTrack)
+
+    /// Tell the user a session just ended.
+    case notifyCompleted(kind: SessionType)
+
+    /// Play the completion sound (subject to the engine's config flags).
+    case playCompletionSound
+
+    /// Flash the "session complete" visual state for the shell's UX cooldown.
+    case flashCompletion
+
+    /// Begin the auto-start countdown that leads into the next session.
+    case scheduleAutoStartCountdown
+}

--- a/Oak/Oak/Models/SessionModels.swift
+++ b/Oak/Oak/Models/SessionModels.swift
@@ -2,9 +2,9 @@ import Foundation
 
 internal enum SessionState: Equatable {
     case idle
-    case running(remainingSeconds: Int, isWorkSession: Bool)
-    case paused(remainingSeconds: Int, isWorkSession: Bool)
-    case completed(isWorkSession: Bool)
+    case running(remainingSeconds: Int, kind: SessionType)
+    case paused(remainingSeconds: Int, kind: SessionType)
+    case completed(kind: SessionType)
 }
 
 internal enum Preset: CaseIterable {

--- a/Oak/Oak/ViewModels/FocusSessionViewModel.swift
+++ b/Oak/Oak/ViewModels/FocusSessionViewModel.swift
@@ -90,8 +90,8 @@ internal class FocusSessionViewModel: ObservableObject {
         case let .running(remaining, _), let .paused(remaining, _):
             minutes = remaining / 60
             seconds = remaining % 60
-        case let .completed(isWorkSession):
-            if isWorkSession {
+        case let .completed(kind):
+            if kind == .work {
                 if shouldUseLongBreak {
                     minutes = presetSettings.longBreakDuration(for: selectedPreset) / 60
                 } else {
@@ -132,14 +132,14 @@ internal class FocusSessionViewModel: ObservableObject {
         switch sessionState {
         case .idle:
             "Ready"
-        case let .running(_, isWork), let .paused(_, isWork):
-            if isWork {
-                "Focus"
-            } else {
-                isLongBreak ? "Long Break" : "Break"
+        case let .running(_, kind), let .paused(_, kind):
+            switch kind {
+            case .work: "Focus"
+            case .shortBreak: "Break"
+            case .longBreak: "Long Break"
             }
-        case let .completed(isWorkSession):
-            if isWorkSession {
+        case let .completed(kind):
+            if kind == .work {
                 if shouldUseLongBreak {
                     "Long Break"
                 } else {
@@ -180,6 +180,14 @@ internal class FocusSessionViewModel: ObservableObject {
 
     private var shouldUseLongBreak: Bool {
         completedRoundsForCurrentDay >= presetSettings.roundsBeforeLongBreak
+    }
+
+    private var currentSessionKind: SessionType {
+        if isWorkSession {
+            .work
+        } else {
+            isLongBreak ? .longBreak : .shortBreak
+        }
     }
 
     private func resetCompletedRoundsIfNeeded() {
@@ -223,7 +231,7 @@ internal extension FocusSessionViewModel {
         sessionStartSeconds = currentRemainingSeconds
         currentSessionStartTime = Date()
         completedRounds = 0
-        sessionState = .running(remainingSeconds: currentRemainingSeconds, isWorkSession: isWorkSession)
+        sessionState = .running(remainingSeconds: currentRemainingSeconds, kind: currentSessionKind)
         startTimer()
     }
 
@@ -232,18 +240,18 @@ internal extension FocusSessionViewModel {
         timer = nil
         sessionEndDate = nil
         audioManager.pause()
-        sessionState = .paused(remainingSeconds: currentRemainingSeconds, isWorkSession: isWorkSession)
+        sessionState = .paused(remainingSeconds: currentRemainingSeconds, kind: currentSessionKind)
     }
 
     func resumeSession() {
         audioManager.resume()
-        sessionState = .running(remainingSeconds: currentRemainingSeconds, isWorkSession: isWorkSession)
+        sessionState = .running(remainingSeconds: currentRemainingSeconds, kind: currentSessionKind)
         startTimer()
     }
 
     func startNextSession(isAutoStart: Bool = false) {
         resetCompletedRoundsIfNeeded()
-        guard case let .completed(completedWorkSession) = sessionState else {
+        guard case let .completed(completedKind) = sessionState else {
             return
         }
 
@@ -254,7 +262,7 @@ internal extension FocusSessionViewModel {
         }
 
         wasAutoStarted = isAutoStart
-        isWorkSession = !completedWorkSession
+        isWorkSession = (completedKind != .work)
 
         if isWorkSession {
             currentRemainingSeconds = presetSettings.workDuration(for: selectedPreset)
@@ -271,7 +279,7 @@ internal extension FocusSessionViewModel {
 
         sessionStartSeconds = currentRemainingSeconds
         currentSessionStartTime = Date()
-        sessionState = .running(remainingSeconds: currentRemainingSeconds, isWorkSession: isWorkSession)
+        sessionState = .running(remainingSeconds: currentRemainingSeconds, kind: currentSessionKind)
 
         if isWorkSession && lastPlayingAudioTrack != .none {
             audioManager.play(track: lastPlayingAudioTrack)
@@ -320,7 +328,7 @@ internal extension FocusSessionViewModel {
         if currentRemainingSeconds <= 0 {
             completeSession()
         } else {
-            sessionState = .running(remainingSeconds: currentRemainingSeconds, isWorkSession: isWorkSession)
+            sessionState = .running(remainingSeconds: currentRemainingSeconds, kind: currentSessionKind)
         }
     }
 
@@ -367,7 +375,7 @@ internal extension FocusSessionViewModel {
         timer?.invalidate()
         timer = nil
         sessionEndDate = nil
-        sessionState = .completed(isWorkSession: isWorkSession)
+        sessionState = .completed(kind: currentSessionKind)
 
         isSessionComplete = true
 

--- a/Oak/Oak/Views/NotchCompanionView.swift
+++ b/Oak/Oak/Views/NotchCompanionView.swift
@@ -115,7 +115,7 @@ internal struct NotchCompanionView: View {
                 withAnimation(.spring(response: 0.3, dampingFraction: 0.7)) {
                     animateCompletion = true
                 }
-                if case let .completed(isWorkSession) = viewModel.sessionState, isWorkSession {
+                if case let .completed(kind) = viewModel.sessionState, kind == .work {
                     showConfetti = true
                     DispatchQueue.main.asyncAfter(deadline: .now() + ConfettiView.animationDuration) {
                         showConfetti = false

--- a/Oak/Tests/OakTests/LongBreakTests.swift
+++ b/Oak/Tests/OakTests/LongBreakTests.swift
@@ -102,8 +102,8 @@ internal final class LongBreakTests: XCTestCase {
             XCTAssertEqual(viewModel.completedRounds, round)
 
             viewModel.startNextSession()
-            if case let .running(remaining, isWork) = viewModel.sessionState {
-                XCTAssertFalse(isWork)
+            if case let .running(remaining, kind) = viewModel.sessionState {
+                XCTAssertNotEqual(kind, .work)
                 XCTAssertEqual(
                     remaining,
                     presetSettings.breakDuration(for: .short)
@@ -126,8 +126,8 @@ internal final class LongBreakTests: XCTestCase {
         viewModel.startNextSession()
         XCTAssertEqual(viewModel.currentSessionType, "Long Break")
 
-        if case let .running(remaining, isWork) = viewModel.sessionState {
-            XCTAssertFalse(isWork)
+        if case let .running(remaining, kind) = viewModel.sessionState {
+            XCTAssertNotEqual(kind, .work)
             XCTAssertEqual(
                 remaining,
                 presetSettings.longBreakDuration(for: .short)
@@ -230,8 +230,8 @@ internal final class LongBreakTests: XCTestCase {
         viewModel.startNextSession()
         XCTAssertEqual(viewModel.currentSessionType, "Long Break")
 
-        if case let .running(remaining, isWork) = viewModel.sessionState {
-            XCTAssertFalse(isWork)
+        if case let .running(remaining, kind) = viewModel.sessionState {
+            XCTAssertNotEqual(kind, .work)
             XCTAssertEqual(
                 remaining,
                 presetSettings.longBreakDuration(for: .long)
@@ -288,8 +288,8 @@ internal final class LongBreakTests: XCTestCase {
 
         viewModel.startNextSession()
 
-        if case let .running(remaining, isWork) = viewModel.sessionState {
-            XCTAssertFalse(isWork)
+        if case let .running(remaining, kind) = viewModel.sessionState {
+            XCTAssertNotEqual(kind, .work)
             XCTAssertEqual(remaining, 30 * 60)
         } else {
             XCTFail("Should be in running state")

--- a/Oak/Tests/OakTests/NotchCompanionViewTests+SessionState.swift
+++ b/Oak/Tests/OakTests/NotchCompanionViewTests+SessionState.swift
@@ -112,8 +112,8 @@ internal extension NotchCompanionViewTests {
         viewModel.startSession(using: .short)
         XCTAssertTrue(viewModel.isRunning, "Precondition: session must be running")
         viewModel.completeSession()
-        if case let .completed(isWorkSession) = viewModel.sessionState {
-            XCTAssertTrue(isWorkSession, "Completing a work session should set isWorkSession=true in state")
+        if case let .completed(kind) = viewModel.sessionState {
+            XCTAssertEqual(kind, .work, "Completing a work session should set kind=.work in state")
         } else {
             XCTFail("Session state should be .completed after completeSession")
         }

--- a/Oak/Tests/OakTests/SessionEngineTests.swift
+++ b/Oak/Tests/OakTests/SessionEngineTests.swift
@@ -1,0 +1,295 @@
+import XCTest
+@testable import Oak
+
+internal final class SessionEngineTests: XCTestCase {
+    // MARK: - Helpers
+
+    private static let testConfig = SessionConfig(
+        workSeconds: 25 * 60,
+        breakSeconds: 5 * 60,
+        longBreakSeconds: 15 * 60,
+        roundsBeforeLongBreak: 4,
+        playSoundOnSessionCompletion: true,
+        playSoundOnBreakCompletion: true,
+        autoStartNextInterval: false
+    )
+
+    private func makeEngine(
+        config: SessionConfig = testConfig,
+        calendar: Calendar = .current,
+        now: Date = Date(timeIntervalSince1970: 1700000000)
+    ) -> SessionEngine {
+        SessionEngine(config: config, calendar: calendar, now: now)
+    }
+
+    private func at(
+        _ offsetSeconds: TimeInterval,
+        base: Date = Date(timeIntervalSince1970: 1700000000)
+    ) -> Date {
+        base.addingTimeInterval(offsetSeconds)
+    }
+
+    // MARK: - Initial state
+
+    func testEngineStartsIdleWithZeroRounds() {
+        let engine = makeEngine()
+        XCTAssertEqual(engine.state, .idle)
+        XCTAssertEqual(engine.completedRounds, 0)
+        XCTAssertNil(engine.nextSessionPreview)
+    }
+
+    // MARK: - Start
+
+    func testStartFromIdleEntersRunningWork() {
+        var engine = makeEngine(now: at(0))
+        let intents = engine.apply(.start(now: at(0)))
+        XCTAssertEqual(intents, [])
+        XCTAssertEqual(engine.state, .running(remainingSeconds: 25 * 60, kind: .work))
+    }
+
+    func testStartIgnoredWhileRunning() {
+        var engine = makeEngine(now: at(0))
+        _ = engine.apply(.start(now: at(0)))
+        let intents = engine.apply(.start(now: at(1)))
+        XCTAssertEqual(intents, [])
+        XCTAssertEqual(engine.state, .running(remainingSeconds: 25 * 60, kind: .work))
+    }
+
+    // MARK: - Tick
+
+    func testTickAdvancesRemainingSeconds() {
+        var engine = makeEngine(now: at(0))
+        _ = engine.apply(.start(now: at(0)))
+        _ = engine.apply(.tick(now: at(60)))
+        XCTAssertEqual(engine.state, .running(remainingSeconds: 24 * 60, kind: .work))
+    }
+
+    func testTickAtZeroCompletesWorkSession() {
+        var engine = makeEngine(now: at(0))
+        _ = engine.apply(.start(now: at(0)))
+        let intents = engine.apply(.tick(now: at(TimeInterval(25 * 60))))
+
+        XCTAssertEqual(engine.state, .completed(kind: .work))
+        XCTAssertEqual(engine.completedRounds, 1)
+
+        XCTAssertTrue(intents.contains(.notifyCompleted(kind: .work)))
+        XCTAssertTrue(intents.contains(.stopAudio))
+        XCTAssertTrue(intents.contains(.playCompletionSound))
+        XCTAssertTrue(intents.contains(.flashCompletion))
+        XCTAssertFalse(intents.contains(.scheduleAutoStartCountdown))
+    }
+
+    // MARK: - Pause / Resume
+
+    func testPauseFromRunningEmitsPauseAudio() {
+        var engine = makeEngine(now: at(0))
+        _ = engine.apply(.start(now: at(0)))
+        _ = engine.apply(.tick(now: at(60)))
+        let intents = engine.apply(.pause(now: at(60)))
+        XCTAssertEqual(intents, [.pauseAudio])
+        XCTAssertEqual(engine.state, .paused(remainingSeconds: 24 * 60, kind: .work))
+    }
+
+    func testResumeFromPausedEmitsResumePausedAudio() {
+        var engine = makeEngine(now: at(0))
+        _ = engine.apply(.start(now: at(0)))
+        _ = engine.apply(.tick(now: at(60)))
+        _ = engine.apply(.pause(now: at(60)))
+        let intents = engine.apply(.resume(now: at(120)))
+        XCTAssertEqual(intents, [.resumePausedAudio])
+        XCTAssertEqual(engine.state, .running(remainingSeconds: 24 * 60, kind: .work))
+    }
+
+    func testPauseIgnoredWhenNotRunning() {
+        var engine = makeEngine(now: at(0))
+        let intents = engine.apply(.pause(now: at(0)))
+        XCTAssertEqual(intents, [])
+        XCTAssertEqual(engine.state, .idle)
+    }
+
+    // MARK: - Long Break decision
+
+    func testShortBreakIsChosenBeforeRoundsThreshold() {
+        var engine = makeEngine(now: at(0))
+        _ = engine.apply(.start(now: at(0)))
+        _ = engine.apply(.tick(now: at(TimeInterval(25 * 60))))
+
+        XCTAssertEqual(engine.nextSessionPreview, .shortBreak)
+
+        _ = engine.apply(.startNext(now: at(TimeInterval(25 * 60)), isAutoStart: false))
+        XCTAssertEqual(engine.state, .running(remainingSeconds: 5 * 60, kind: .shortBreak))
+    }
+
+    func testLongBreakIsChosenAfterFourCompletedRounds() {
+        var engine = makeEngine(now: at(0))
+        var elapsed: TimeInterval = 0
+
+        _ = engine.apply(.start(now: at(elapsed))) // first work session
+
+        for round in 1 ... 4 {
+            elapsed += 25 * 60
+            _ = engine.apply(.tick(now: at(elapsed))) // completes work
+            XCTAssertEqual(engine.completedRounds, round)
+
+            if round < 4 {
+                _ = engine.apply(.startNext(now: at(elapsed), isAutoStart: false)) // break
+                elapsed += 5 * 60
+                _ = engine.apply(.tick(now: at(elapsed))) // completes break
+                _ = engine.apply(.startNext(now: at(elapsed), isAutoStart: false)) // next work
+            }
+        }
+
+        XCTAssertEqual(engine.completedRounds, 4)
+        XCTAssertEqual(engine.state, .completed(kind: .work))
+        XCTAssertEqual(engine.nextSessionPreview, .longBreak)
+
+        _ = engine.apply(.startNext(now: at(elapsed), isAutoStart: false))
+        XCTAssertEqual(engine.state, .running(remainingSeconds: 15 * 60, kind: .longBreak))
+    }
+
+    func testCompletingLongBreakResetsRoundsToZero() {
+        var engine = makeEngine(
+            config: SessionConfig(
+                workSeconds: 25 * 60,
+                breakSeconds: 5 * 60,
+                longBreakSeconds: 15 * 60,
+                roundsBeforeLongBreak: 1, // shortcut: long break after 1 round
+                playSoundOnSessionCompletion: false,
+                playSoundOnBreakCompletion: false,
+                autoStartNextInterval: false
+            ),
+            now: at(0)
+        )
+
+        _ = engine.apply(.start(now: at(0)))
+        _ = engine.apply(.tick(now: at(TimeInterval(25 * 60)))) // complete work, rounds=1
+        XCTAssertEqual(engine.completedRounds, 1)
+
+        _ = engine.apply(.startNext(now: at(TimeInterval(25 * 60)), isAutoStart: false))
+        XCTAssertEqual(engine.state, .running(remainingSeconds: 15 * 60, kind: .longBreak))
+
+        _ = engine.apply(.tick(now: at(TimeInterval(40 * 60)))) // complete long break
+        XCTAssertEqual(engine.completedRounds, 0)
+    }
+
+    // MARK: - Day rollover
+
+    func testNewDayResetsRoundsOnStart() {
+        var engine = makeEngine(now: at(0))
+        _ = engine.apply(.start(now: at(0)))
+        _ = engine.apply(.tick(now: at(TimeInterval(25 * 60))))
+        XCTAssertEqual(engine.completedRounds, 1)
+        _ = engine.apply(.reset)
+
+        // Move two days forward; `.start` should reset completed rounds.
+        let nextDay = at(0).addingTimeInterval(2 * 24 * 60 * 60)
+        _ = engine.apply(.start(now: nextDay))
+        XCTAssertEqual(engine.completedRounds, 0)
+    }
+
+    // MARK: - Audio remember-and-resume
+
+    func testWorkCompletionRemembersCurrentlyPlayingTrack() {
+        var engine = makeEngine(now: at(0))
+        engine.setCurrentlyPlayingAudio(.rain)
+        _ = engine.apply(.start(now: at(0)))
+        _ = engine.apply(.tick(now: at(TimeInterval(25 * 60))))
+
+        // Next work start should emit `.startRememberedAudio(.rain)`.
+        engine.setCurrentlyPlayingAudio(.none) // audio is stopped
+        _ = engine.apply(.startNext(now: at(TimeInterval(25 * 60)), isAutoStart: false)) // .shortBreak
+        let breakDone = at(TimeInterval(30 * 60))
+        _ = engine.apply(.tick(now: breakDone)) // complete break
+        let intents = engine.apply(.startNext(now: breakDone, isAutoStart: false))
+        XCTAssertTrue(intents.contains(.startRememberedAudio(track: .rain)))
+    }
+
+    func testCompletionWithNoPlayingAudioDoesNotOverwriteRememberedTrack() {
+        var engine = makeEngine(now: at(0))
+        engine.setCurrentlyPlayingAudio(.rain)
+        _ = engine.apply(.start(now: at(0)))
+        _ = engine.apply(.tick(now: at(TimeInterval(25 * 60)))) // remembers rain
+
+        engine.setCurrentlyPlayingAudio(.none)
+        _ = engine.apply(.startNext(now: at(TimeInterval(25 * 60)), isAutoStart: false))
+        _ = engine.apply(.tick(now: at(TimeInterval(30 * 60)))) // break completes, nothing playing
+
+        // Rain should still be remembered. Next work start emits it.
+        let intents = engine.apply(.startNext(now: at(TimeInterval(30 * 60)), isAutoStart: false))
+        XCTAssertTrue(intents.contains(.startRememberedAudio(track: .rain)))
+    }
+
+    // MARK: - Completion sound config
+
+    func testBreakCompletionSoundSuppressedOnAutoStartedBreak() {
+        var engine = makeEngine(
+            config: SessionConfig(
+                workSeconds: 25 * 60,
+                breakSeconds: 5 * 60,
+                longBreakSeconds: 15 * 60,
+                roundsBeforeLongBreak: 4,
+                playSoundOnSessionCompletion: true,
+                playSoundOnBreakCompletion: true,
+                autoStartNextInterval: false
+            ),
+            now: at(0)
+        )
+
+        _ = engine.apply(.start(now: at(0)))
+        _ = engine.apply(.tick(now: at(TimeInterval(25 * 60)))) // complete work
+        _ = engine.apply(.startNext(now: at(TimeInterval(25 * 60)), isAutoStart: true)) // auto-started break
+        let intents = engine.apply(.tick(now: at(TimeInterval(30 * 60)))) // complete break
+
+        XCTAssertFalse(
+            intents.contains(.playCompletionSound),
+            "Break completion sound should not play when break was auto-started"
+        )
+    }
+
+    func testAutoStartNextScheduledOnCompletionWhenEnabled() {
+        var engine = makeEngine(
+            config: SessionConfig(
+                workSeconds: 25 * 60,
+                breakSeconds: 5 * 60,
+                longBreakSeconds: 15 * 60,
+                roundsBeforeLongBreak: 4,
+                playSoundOnSessionCompletion: false,
+                playSoundOnBreakCompletion: false,
+                autoStartNextInterval: true
+            ),
+            now: at(0)
+        )
+
+        _ = engine.apply(.start(now: at(0)))
+        let intents = engine.apply(.tick(now: at(TimeInterval(25 * 60))))
+        XCTAssertTrue(intents.contains(.scheduleAutoStartCountdown))
+    }
+
+    // MARK: - Recording
+
+    func testCompletionEmitsRecordWithCorrectKindAndDuration() {
+        var engine = makeEngine(now: at(0))
+        _ = engine.apply(.start(now: at(0)))
+        let intents = engine.apply(.tick(now: at(TimeInterval(25 * 60))))
+
+        let record = intents.compactMap { intent -> SessionRecord? in
+            if case let .recordCompletion(record) = intent { return record }
+            return nil
+        }.first
+
+        XCTAssertNotNil(record)
+        XCTAssertEqual(record?.type, .work)
+        XCTAssertEqual(record?.durationMinutes, 25)
+    }
+
+    // MARK: - Reset
+
+    func testResetReturnsToIdleAndStopsAudio() {
+        var engine = makeEngine(now: at(0))
+        _ = engine.apply(.start(now: at(0)))
+        let intents = engine.apply(.reset)
+        XCTAssertEqual(intents, [.stopAudio])
+        XCTAssertEqual(engine.state, .idle)
+        XCTAssertEqual(engine.completedRounds, 0)
+    }
+}

--- a/Oak/Tests/OakTests/US005Tests.swift
+++ b/Oak/Tests/OakTests/US005Tests.swift
@@ -42,8 +42,8 @@ internal final class US005Tests: XCTestCase {
         viewModel.startSession()
         viewModel.completeSession()
 
-        if case let .completed(isWorkSession) = viewModel.sessionState {
-            XCTAssertTrue(isWorkSession, "Should be a completed work session")
+        if case let .completed(kind) = viewModel.sessionState {
+            XCTAssertEqual(kind, .work, "Should be a completed work session")
         } else {
             XCTFail("Expected .completed state, got \(viewModel.sessionState)")
         }

--- a/doc/adr/0004-session-engine-as-functional-core.md
+++ b/doc/adr/0004-session-engine-as-functional-core.md
@@ -1,0 +1,99 @@
+# 0004. Session Engine as Functional Core
+
+Date: 2026-05-25
+
+## Status
+
+Accepted
+
+## Context
+
+`FocusSessionViewModel` had grown to 405 lines and conflated four concerns behind one interface:
+
+1. The Focus Session finite state machine (`idle` → `running` → `paused` → `completed`)
+2. Wall-clock timers (`Timer.scheduledTimer` for ticks; a second `Timer` for the auto-start countdown)
+3. Side-effect orchestration (audio, notifications, completion sound, progress recording, completion-flash animation, auto-start scheduling)
+4. SwiftUI publishing
+
+The view model required six constructor collaborators (`PresetSettingsStore`, `AudioManager`, `ProgressManager`, `SessionCompletionNotifying`, `SessionCompletionSoundPlaying`, `currentDate: () -> Date`) to answer any behavioural question. Round-counting and day-rollover logic was duplicated between the view model and `ProgressManager` — the recent "refresh day rollover and reset rounds" fix had to touch both files.
+
+The **Session Kind** of a session existed in three representations: `SessionState.running(isWorkSession: Bool)`, a private `isLongBreak: Bool` on the view model, and the `SessionType` enum used by `SessionRecord`.
+
+Tests were constructing the full collaborator graph (`MockAudioManager`, `MockNotificationService`, `currentDate` closures) to verify pure FSM behaviour like "after 3 rounds the next break is long".
+
+## Decision
+
+Extract a pure `SessionEngine` as the functional core of Focus Session behaviour, with `FocusSessionViewModel` reduced to an imperative shell.
+
+The engine is a **`struct`** with `mutating` event application:
+
+```swift
+struct SessionEngine {
+    private(set) var state: SessionState
+    private(set) var completedRounds: Int
+    var nextSessionPreview: SessionType? { … }
+
+    init(config: SessionConfig, calendar: Calendar = .current, now: Date)
+
+    mutating func updateConfig(_ new: SessionConfig)
+    mutating func setCurrentlyPlayingAudio(_ track: AudioTrack)
+    mutating func apply(_ event: SessionEvent) -> [SessionIntent]
+}
+```
+
+The engine **owns**:
+
+- The `SessionState` FSM and its transitions
+- Round counting and the Long Break decision
+- Day-rollover-driven round reset (via an injected `Calendar`)
+- The `lastPlayingAudioTrack` memory for audio resumption
+- Duration math from `SessionConfig`
+- Emission of `SessionIntent` values describing the side effects required
+
+The engine **does not own**:
+
+- Timers (the shell owns both the session ticking `Timer` and the auto-start countdown `Timer`)
+- `AudioManager`, `NotificationService`, `ProgressManager`, `SessionCompletionSoundPlaying` (the shell holds these and executes intents against them)
+- The 1.5s completion-flash flag or the auto-start countdown counter (purely visual timing, owned by the shell)
+- `@Published` plumbing or any SwiftUI dependency
+- Any direct subscription to `PresetSettingsStore` or `AudioManager` (the shell pushes updates via `updateConfig` and `setCurrentlyPlayingAudio`)
+
+### State carries Session Kind
+
+`SessionState` is rewritten to carry `SessionType` instead of `isWorkSession: Bool`. The private `isLongBreak: Bool` flag is deleted. The Session Kind has one representation across the FSM, progress recording, and notifications.
+
+### Intents over delegate
+
+The engine returns `[SessionIntent]` from each `apply(...)` call. The shell dispatches each intent to the appropriate service. This was chosen over a delegate protocol because:
+
+- Side-effect order becomes explicit in the returned array
+- Tests assert on intent arrays directly without any mock
+- The engine has no reference-typed collaborators to reason about
+
+### Time pushed in per event
+
+Every `SessionEvent` carries `now: Date`. The engine has no `currentDate: () -> Date` closure and no shared clock. Tests advance time by passing different `Date` values to `tick`. The engine uses an injected `Calendar` (default `.current`) for day-rollover detection.
+
+## Consequences
+
+### Positive
+
+- **Locality**: round tracking, Long Break decision, day rollover, and audio-memory rules concentrate in one ~200-line file with one test suite.
+- **Leverage**: every behavioural question becomes a pure synchronous test — no mocks, no `MainActor`, no clock closures, no sleeps.
+- The view model shrinks to a thin shell — timer plumbing, Combine subscriptions, and intent dispatch. Most of its remaining lines are glue, not logic.
+- Session Kind has a single representation (`SessionType`).
+- `SessionState` becomes self-describing — `kind` lives in the enum case, not a parallel field.
+
+### Negative
+
+- The engine imports `AudioTrack` (a small but real dependency on the audio model) because it owns `lastPlayingAudioTrack`.
+- A `SessionConfig` snapshot must be kept in sync by the shell whenever `PresetSettingsStore` publishes — an extra Combine subscription.
+- Day-rollover logic now lives in two places (`SessionEngine` and `ProgressManager`). Consolidating them under a shared `DayClock` is deferred until both modules are clean and the seam is real (per the "one adapter is a hypothetical seam" rule).
+
+### Rejected alternatives
+
+- **Engine as a `class` or `actor`**: rejected. Value semantics bulletproof tests, eliminate `[weak self]` ceremony, and avoid forcing the FSM into `async` when it has no concurrency to manage.
+- **Delegate protocol for side effects**: rejected. Re-introduces the mock-graph problem that motivated the refactor and hides side-effect ordering.
+- **Engine holds a `PresetSettingsStore` reference**: rejected. Forces the engine into `@MainActor` and Combine, defeating the purity.
+- **Shell owns `lastPlayingAudioTrack`**: rejected for cohesion — every piece of session memory that survives across event boundaries should live in one place.
+- **Shared `DayClock` seam introduced now** (the original Candidate 2): rejected. The view model and `ProgressManager` rollover triggers run on different cadences (user events vs. 60s polling); the seam is hypothetical until both modules are clean enough to share a real one.


### PR DESCRIPTION
## What

Adds a pure `SessionEngine` struct alongside `FocusSessionViewModel` — **no callers yet**. The engine is the functional core that will eventually own Focus Session lifecycle, Round tracking, Long Break decisions, and audio-resume memory; the view model will become a thin shell that dispatches the `SessionIntent` values the engine emits.

New types in [`Oak/Oak/Models/`](Oak/Oak/Models):
- `SessionEngine` — pure `struct` FSM, no Foundation side effects, time pushed in per event via `now: Date`
- `SessionConfig` — value snapshot of the preferences the engine reads
- `SessionEvent` — `start` / `pause` / `resume` / `tick` / `startNext` / `reset`
- `SessionIntent` — equatable side-effect commands for the shell to execute

`SessionState` was reshaped to carry `SessionType` instead of `isWorkSession: Bool`, unifying the three pre-existing representations of session kind (FSM enum bool, VM's private `isLongBreak`, and `SessionType` from `SessionRecord`).

**18 new pure-engine tests** in [`SessionEngineTests.swift`](Oak/Tests/OakTests/SessionEngineTests.swift) — synchronous, no mocks, no `MainActor`, run in 10ms total. They cover FSM transitions, round counting, long-break decision after 4 rounds, day-rollover round reset, audio remember-and-resume across breaks, the auto-started-break sound-suppression rule, auto-start scheduling, and `SessionRecord` emission.

## Why

`FocusSessionViewModel` had grown to 405 lines and conflated four concerns behind one interface: the session FSM, two `Timer.scheduledTimer`s, side-effect orchestration across six injected collaborators, and SwiftUI publishing. Any behavioural question ("after 3 rounds, what kind of break starts?") required constructing `MockAudioManager`, `MockNotificationService`, a `currentDate: () -> Date` closure, and the full `PresetSettingsStore`. Day-rollover and round-tracking logic was duplicated between the VM and `ProgressManager` — the recent #114 fix "refresh day rollover and reset rounds" had to touch both files.

This is the first of three phases that move session-FSM logic into a pure functional core where the interface itself is the test surface (see [LANGUAGE.md](https://github.com/jellydn/amp-improve-codebase-architecture/blob/main/LANGUAGE.md) for the principles).

## How

Three-phase migration to keep the test suite green throughout:

- **Phase 1 (this PR)**: add `SessionEngine` + its supporting value types + the new state shape. VM still implements the FSM inline; the 240 existing tests pass unchanged (only enum-case shapes were updated to compile against the new `SessionState`).
- **Phase 2**: wire VM to delegate to engine, delete its private FSM fields, keep the `@Published` surface stable.
- **Phase 3**: port `LongBreakTests` / `US006Tests` behaviour assertions into `SessionEngineTests` and shrink the VM test surface.

Design decisions captured in [ADR-0004](doc/adr/0004-session-engine-as-functional-core.md), with rejected alternatives (delegate over intents, class over struct, shared `DayClock` consolidation, shell-owned audio memory) documented so future architecture reviews don't re-litigate them. New domain terms (Session Engine / Event / Intent / Config) added to [CONTEXT.md](CONTEXT.md) without disturbing existing language.

Notable trade-offs:
- The engine imports `AudioTrack` (a small but real dependency) because it owns `lastPlayingAudioTrack` for cohesion — every piece of cross-event session memory lives in one place.
- Day-rollover logic now lives in two places (`SessionEngine` and `ProgressManager`). Consolidating under a shared `DayClock` is deferred until both modules are clean — per the "one adapter is a hypothetical seam, two adapters is a real seam" rule.

## Checklist

- [x] Tests added (18 new `SessionEngineTests`)
- [x] Documentation updated (`CONTEXT.md`, `doc/adr/0004-…`)
- [x] No breaking changes to public app behaviour (engine has no callers yet)
- [x] `just build`, `just test`, `just check-style` all green