### PR TITLE
docs: mark pre-existing format issues as resolved in CONCERNS.md

### DIFF
--- a/.planning/codebase/CONCERNS.md
+++ b/.planning/codebase/CONCERNS.md
@@ -10,14 +10,14 @@
 - **Workaround**: None — requires full Xcode installation
 - **File**: `.swiftlint.yml`
 
-### 2. Pre-Existing Format Issues
+### 2. Pre-Existing Format Issues — RESOLVED
 
-Two files fail `just format-check` due to `wrapIfStatementBodies` violations:
+Two files previously failed `just format-check` due to `wrapIfStatementBodies` violations:
 
-- `Oak/Oak/ViewModels/FocusSessionViewModel.swift` — 12 violations
-- `Oak/Tests/OakTests/AudioManagerTests.swift` — 2 violations
+- `Oak/Oak/ViewModels/FocusSessionViewModel.swift` — 12 violations (fixed in v0.5.34)
+- `Oak/Tests/OakTests/AudioManagerTests.swift` — 2 violations (fixed in v0.5.34)
 
-These block git commits when pre-commit hooks are enabled.
+Format-check now passes with 0 violations.
 
 ### 3. Building Requires Full Xcode
 


### PR DESCRIPTION
## What

Marked the pre-existing `wrapIfStatementBodies` format issues as resolved in CONCERNS.md. These violations were fixed in v0.5.34 — both FocusSessionViewModel.swift (12 violations) and AudioManagerTests.swift (2 violations) now pass `just format-check` with 0 errors.

## Why

CONCERNS.md listed the format issues as active known issues, but they were resolved during the v0.5.34 cleanup. Keeping them listed as unresolved is misleading for developers and AI agents reading the codebase map.

## How

- Updated section "2. Pre-Existing Format Issues" to "Pre-Existing Format Issues — RESOLVED"
- Added resolution notes referencing v0.5.34
- Noted that format-check now passes with 0 violations

## Checklist

- [ ] Tests added or updated
- [x] Documentation updated
- [x] No breaking changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated formatting documentation to reflect that previously reported format-check issues have been resolved.
  * Confirmed that formatting validation now passes without violations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->