### PR TITLE
refactor: extract timer logic from FocusSessionViewModel into SessionTimerService

### DIFF
--- a/Oak/Oak.xcodeproj/project.pbxproj
+++ b/Oak/Oak.xcodeproj/project.pbxproj
@@ -73,6 +73,7 @@
 		ED83D72FEA74BD4FB1A307DE /* AudioManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B1E09A351763DC5E48FA361 /* AudioManagerTests.swift */; };
 		F1267A7C11F901A5AE9D6EDF /* NotchVisualStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DCAC7004FB57BBA5CEBB9B3 /* NotchVisualStyle.swift */; };
 		F32ECEC3C32292DC1969C472 /* SessionCompletionNotificationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 131CDA9D17A7D22CBC67785C /* SessionCompletionNotificationTests.swift */; };
+		F51DE81C4543A035DA93A6F7 /* SessionTimerService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18F2F3DEA012EE98A549BC02 /* SessionTimerService.swift */; };
 		F7D47435500BDC1F9A6E1B5A /* US005Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 732AEE30E8FEC2D900C8224A /* US005Tests.swift */; };
 /* End PBXBuildFile section */
 
@@ -99,6 +100,7 @@
 		1387A36E301B5A6EA9BB4A85 /* PresetSettingsStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PresetSettingsStore.swift; sourceTree = "<group>"; };
 		14E1129CEDF63355578B0485 /* ConfettiViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfettiViewTests.swift; sourceTree = "<group>"; };
 		164FAFB05B901C05BD1479BF /* NotchLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotchLayout.swift; sourceTree = "<group>"; };
+		18F2F3DEA012EE98A549BC02 /* SessionTimerService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionTimerService.swift; sourceTree = "<group>"; };
 		1B9D70365997A0BB1C917839 /* ambient_cafe.m4a */ = {isa = PBXFileReference; path = ambient_cafe.m4a; sourceTree = "<group>"; };
 		1CDDE42AD58F6B067B64ED90 /* ProgressData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProgressData.swift; sourceTree = "<group>"; };
 		1E53FB903AF7AF6B4DE091AD /* AccessibilityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccessibilityTests.swift; sourceTree = "<group>"; };
@@ -308,6 +310,7 @@
 				98D555E4182E199E8EC8D0B3 /* NotificationService.swift */,
 				1387A36E301B5A6EA9BB4A85 /* PresetSettingsStore.swift */,
 				6EFD132B19656D2C6D2CA981 /* ProgressManager.swift */,
+				18F2F3DEA012EE98A549BC02 /* SessionTimerService.swift */,
 				770CCC886CF6A5E903159704 /* SparkleUpdater.swift */,
 			);
 			path = Services;
@@ -449,6 +452,7 @@
 				E3BAB7635E9F5CEAABADB263 /* ProgressManager.swift in Sources */,
 				C1C2CDACE52EEF5146C83881 /* ProgressMenuView.swift in Sources */,
 				CE3A4934C57D1C203D016F96 /* SessionModels.swift in Sources */,
+				F51DE81C4543A035DA93A6F7 /* SessionTimerService.swift in Sources */,
 				716599FCD65FC35919E253E8 /* SettingsMenuView.swift in Sources */,
 				D9BC1320EE869D9AD7FE40AE /* SparkleUpdater.swift in Sources */,
 				91F4096D77B5684A1251EE01 /* SupportSectionView.swift in Sources */,
@@ -643,14 +647,14 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 5032;
+				CURRENT_PROJECT_VERSION = 5035;
 				INFOPLIST_FILE = Oak/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 13.0;
-				MARKETING_VERSION = 0.5.32;
+				MARKETING_VERSION = 0.5.35;
 				PRODUCT_BUNDLE_IDENTIFIER = com.productsway.oak.app;
 				SDKROOT = macosx;
 				SPARKLE_PUBLIC_ED_KEY = "IjFqN1R6i4Dh8IZxQ42RtSEii7pUgS45+NvidSwQup0=";
@@ -679,14 +683,14 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 5032;
+				CURRENT_PROJECT_VERSION = 5035;
 				INFOPLIST_FILE = Oak/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 13.0;
-				MARKETING_VERSION = 0.5.32;
+				MARKETING_VERSION = 0.5.35;
 				PRODUCT_BUNDLE_IDENTIFIER = com.productsway.oak.app;
 				SDKROOT = macosx;
 				SPARKLE_PUBLIC_ED_KEY = "IjFqN1R6i4Dh8IZxQ42RtSEii7pUgS45+NvidSwQup0=";

--- a/Oak/Oak/Services/SessionTimerService.swift
+++ b/Oak/Oak/Services/SessionTimerService.swift
@@ -1,0 +1,108 @@
+import Combine
+import Foundation
+
+// MARK: - SessionTimerService
+
+@MainActor
+internal final class SessionTimerService: ObservableObject {
+    @Published private(set) var remainingSeconds: Int = 0
+    @Published private(set) var autoStartCountdown: Int = 0
+    @Published private(set) var sessionDuration: Int = 0
+
+    let timerFinished = PassthroughSubject<Void, Never>()
+    let autoStartFinished = PassthroughSubject<Void, Never>()
+
+    private var timer: Timer?
+    private var autoStartTimer: Timer?
+    private var sessionEndDate: Date?
+
+    deinit {
+        timer?.invalidate()
+        autoStartTimer?.invalidate()
+    }
+
+    func start(seconds: Int) {
+        timer?.invalidate()
+        sessionDuration = seconds
+        remainingSeconds = seconds
+        sessionEndDate = Date().addingTimeInterval(TimeInterval(seconds))
+        timer = Timer.scheduledTimer(withTimeInterval: 1.0, repeats: true) { [weak self] _ in
+            Task { @MainActor in
+                self?.tick()
+            }
+        }
+    }
+
+    func pause() {
+        timer?.invalidate()
+        timer = nil
+        sessionEndDate = nil
+    }
+
+    func resume() {
+        guard timer == nil else { return }
+        sessionEndDate = Date().addingTimeInterval(TimeInterval(remainingSeconds))
+        timer = Timer.scheduledTimer(withTimeInterval: 1.0, repeats: true) { [weak self] _ in
+            Task { @MainActor in
+                self?.tick()
+            }
+        }
+    }
+
+    func stop() {
+        timer?.invalidate()
+        timer = nil
+        autoStartTimer?.invalidate()
+        autoStartTimer = nil
+        remainingSeconds = 0
+        autoStartCountdown = 0
+        sessionDuration = 0
+        sessionEndDate = nil
+    }
+
+    func startAutoStartCountdown() {
+        autoStartCountdown = 10
+        autoStartTimer?.invalidate()
+        autoStartTimer = Timer.scheduledTimer(withTimeInterval: 1.0, repeats: true) { [weak self] _ in
+            Task { @MainActor in
+                self?.tickAutoStart()
+            }
+        }
+    }
+
+    func cancelAutoStartCountdown() {
+        autoStartTimer?.invalidate()
+        autoStartTimer = nil
+        autoStartCountdown = 0
+    }
+
+    // MARK: - Private
+
+    private func tick() {
+        guard let sessionEndDate else {
+            timer?.invalidate()
+            timer = nil
+            timerFinished.send()
+            return
+        }
+
+        remainingSeconds = max(0, Int(ceil(sessionEndDate.timeIntervalSinceNow)))
+
+        if remainingSeconds <= 0 {
+            timer?.invalidate()
+            timer = nil
+            self.sessionEndDate = nil
+            timerFinished.send()
+        }
+    }
+
+    private func tickAutoStart() {
+        autoStartCountdown -= 1
+        if autoStartCountdown <= 0 {
+            autoStartTimer?.invalidate()
+            autoStartTimer = nil
+            autoStartCountdown = 0
+            autoStartFinished.send()
+        }
+    }
+}

--- a/Oak/Oak/ViewModels/FocusSessionViewModel.swift
+++ b/Oak/Oak/ViewModels/FocusSessionViewModel.swift
@@ -21,23 +21,20 @@ internal class FocusSessionViewModel: ObservableObject {
     @Published private(set) var autoStartCountdown: Int = 0
 
     let presetSettings: PresetSettingsStore
-    private var timer: Timer?
-    private var autoStartTimer: Timer?
-    private var currentRemainingSeconds: Int = 0
     private var isWorkSession: Bool = true
     private var isLongBreak: Bool = false
-    private var sessionStartSeconds: Int = 0
-    private var sessionEndDate: Date?
     private var currentSessionStartTime: Date?
     private let currentDate: () -> Date
     private var roundTrackingDate: Date
     private var presetSettingsCancellable: AnyCancellable?
+    private var timerServiceCancellables = Set<AnyCancellable>()
     private var lastPlayingAudioTrack: AudioTrack = .none
     private var wasAutoStarted: Bool = false
     let audioManager: AudioManager
     let progressManager: ProgressManager
     let notificationService: any SessionCompletionNotifying
     let completionSoundPlayer: any SessionCompletionSoundPlaying
+    let timerService: SessionTimerService
 
     init(
         presetSettings: PresetSettingsStore,
@@ -45,6 +42,7 @@ internal class FocusSessionViewModel: ObservableObject {
         progressManager: ProgressManager? = nil,
         notificationService: any SessionCompletionNotifying,
         completionSoundPlayer: (any SessionCompletionSoundPlaying)? = nil,
+        timerService: SessionTimerService? = nil,
         currentDate: @escaping () -> Date = Date.init
     ) {
         self.currentDate = currentDate
@@ -54,9 +52,11 @@ internal class FocusSessionViewModel: ObservableObject {
         self.progressManager = progressManager ?? ProgressManager()
         self.notificationService = notificationService
         self.completionSoundPlayer = completionSoundPlayer ?? SystemSessionCompletionSoundPlayer()
+        self.timerService = timerService ?? SessionTimerService()
         presetSettingsCancellable = presetSettings.objectWillChange.sink { [weak self] _ in
             self?.objectWillChange.send()
         }
+        setupTimerServiceBindings()
     }
 
     var canStart: Bool {
@@ -119,8 +119,9 @@ internal class FocusSessionViewModel: ObservableObject {
         case .idle:
             return 0.0
         case let .running(remaining, _), let .paused(remaining, _):
-            guard sessionStartSeconds > 0 else { return 0.0 }
-            return Double(sessionStartSeconds - remaining) / Double(sessionStartSeconds)
+            let duration = timerService.sessionDuration
+            guard duration > 0 else { return 0.0 }
+            return Double(duration - remaining) / Double(duration)
         case .completed:
             return 0.0
         }
@@ -204,10 +205,41 @@ internal class FocusSessionViewModel: ObservableObject {
         completedRounds = 0
     }
 
+    private func setupTimerServiceBindings() {
+        timerService.$remainingSeconds
+            .sink { [weak self] remaining in
+                guard let self, case .running = self.sessionState, remaining > 0 else { return }
+                sessionState = .running(remainingSeconds: remaining, isWorkSession: isWorkSession)
+            }
+            .store(in: &timerServiceCancellables)
+
+        timerService.$autoStartCountdown
+            .sink { [weak self] count in
+                self?.autoStartCountdown = count
+            }
+            .store(in: &timerServiceCancellables)
+
+        timerService.timerFinished
+            .sink { [weak self] in
+                self?.completeSession()
+            }
+            .store(in: &timerServiceCancellables)
+
+        timerService.autoStartFinished
+            .sink { [weak self] in
+                guard let self, case .completed = self.sessionState else { return }
+                startNextSession(isAutoStart: true)
+            }
+            .store(in: &timerServiceCancellables)
+    }
+
     deinit {
-        timer?.invalidate()
-        autoStartTimer?.invalidate()
+        let service = timerService
+        Task { @MainActor in
+            service.stop()
+        }
         presetSettingsCancellable?.cancel()
+        timerServiceCancellables.removeAll()
         let manager = audioManager
         Task { @MainActor in
             manager.stop()
@@ -229,28 +261,25 @@ internal extension FocusSessionViewModel {
         if let preset {
             selectedPreset = preset
         }
-        currentRemainingSeconds = presetSettings.workDuration(for: selectedPreset)
+        let seconds = presetSettings.workDuration(for: selectedPreset)
         isWorkSession = true
         isLongBreak = false
-        sessionStartSeconds = currentRemainingSeconds
         currentSessionStartTime = Date()
         completedRounds = 0
-        sessionState = .running(remainingSeconds: currentRemainingSeconds, isWorkSession: isWorkSession)
-        startTimer()
+        sessionState = .running(remainingSeconds: seconds, isWorkSession: isWorkSession)
+        timerService.start(seconds: seconds)
     }
 
     func pauseSession() {
-        timer?.invalidate()
-        timer = nil
-        sessionEndDate = nil
+        timerService.pause()
         audioManager.pause()
-        sessionState = .paused(remainingSeconds: currentRemainingSeconds, isWorkSession: isWorkSession)
+        sessionState = .paused(remainingSeconds: timerService.remainingSeconds, isWorkSession: isWorkSession)
     }
 
     func resumeSession() {
         audioManager.resume()
-        sessionState = .running(remainingSeconds: currentRemainingSeconds, isWorkSession: isWorkSession)
-        startTimer()
+        sessionState = .running(remainingSeconds: timerService.remainingSeconds, isWorkSession: isWorkSession)
+        timerService.resume()
     }
 
     func startNextSession(isAutoStart: Bool = false) {
@@ -259,79 +288,44 @@ internal extension FocusSessionViewModel {
             return
         }
 
-        if autoStartCountdown > 0 {
-            autoStartTimer?.invalidate()
-            autoStartTimer = nil
-            autoStartCountdown = 0
-        }
+        timerService.cancelAutoStartCountdown()
 
         wasAutoStarted = isAutoStart
         isWorkSession = !completedWorkSession
 
+        let seconds: Int
         if isWorkSession {
-            currentRemainingSeconds = presetSettings.workDuration(for: selectedPreset)
+            seconds = presetSettings.workDuration(for: selectedPreset)
             isLongBreak = false
         } else if shouldUseLongBreak {
-            currentRemainingSeconds = presetSettings.longBreakDuration(for: selectedPreset)
+            seconds = presetSettings.longBreakDuration(for: selectedPreset)
             isLongBreak = true
         } else {
-            currentRemainingSeconds = presetSettings.breakDuration(for: selectedPreset)
+            seconds = presetSettings.breakDuration(for: selectedPreset)
             isLongBreak = false
         }
 
-        sessionStartSeconds = currentRemainingSeconds
         currentSessionStartTime = Date()
-        sessionState = .running(remainingSeconds: currentRemainingSeconds, isWorkSession: isWorkSession)
+        sessionState = .running(remainingSeconds: seconds, isWorkSession: isWorkSession)
 
         if isWorkSession && lastPlayingAudioTrack != .none {
             audioManager.play(track: lastPlayingAudioTrack)
         }
 
-        startTimer()
+        timerService.start(seconds: seconds)
     }
 
     func resetSession() {
-        timer?.invalidate()
-        timer = nil
-        autoStartTimer?.invalidate()
-        autoStartTimer = nil
-        currentRemainingSeconds = 0
+        timerService.stop()
         isWorkSession = true
         isLongBreak = false
-        sessionStartSeconds = 0
-        sessionEndDate = nil
         currentSessionStartTime = nil
         isSessionComplete = false
         completedRounds = 0
-        autoStartCountdown = 0
         lastPlayingAudioTrack = .none
         wasAutoStarted = false
         audioManager.stop()
         sessionState = .idle
-    }
-
-    private func startTimer() {
-        timer?.invalidate()
-        sessionEndDate = Date().addingTimeInterval(TimeInterval(currentRemainingSeconds))
-        timer = Timer.scheduledTimer(withTimeInterval: 1.0, repeats: true) { [weak self] _ in
-            Task { @MainActor in
-                self?.tick()
-            }
-        }
-    }
-
-    private func tick() {
-        guard let sessionEndDate else {
-            completeSession()
-            return
-        }
-        currentRemainingSeconds = max(0, Int(ceil(sessionEndDate.timeIntervalSinceNow)))
-
-        if currentRemainingSeconds <= 0 {
-            completeSession()
-        } else {
-            sessionState = .running(remainingSeconds: currentRemainingSeconds, isWorkSession: isWorkSession)
-        }
     }
 
     func completeSession() {
@@ -347,7 +341,8 @@ internal extension FocusSessionViewModel {
             }
         }
 
-        let durationMinutes = (sessionStartSeconds - currentRemainingSeconds) / 60
+        let remaining = timerService.remainingSeconds
+        let durationMinutes = (timerService.sessionDuration - remaining) / 60
         if durationMinutes > 0, let startTime = currentSessionStartTime {
             progressManager.recordSessionCompletion(
                 durationMinutes: durationMinutes,
@@ -374,9 +369,6 @@ internal extension FocusSessionViewModel {
             completionSoundPlayer.playCompletionSound()
         }
 
-        timer?.invalidate()
-        timer = nil
-        sessionEndDate = nil
         sessionState = .completed(isWorkSession: isWorkSession)
 
         isSessionComplete = true
@@ -386,29 +378,7 @@ internal extension FocusSessionViewModel {
             isSessionComplete = false
 
             if presetSettings.autoStartNextInterval {
-                startAutoStartCountdown()
-            }
-        }
-    }
-
-    private func startAutoStartCountdown() {
-        autoStartCountdown = 10
-        autoStartTimer?.invalidate()
-        autoStartTimer = Timer.scheduledTimer(withTimeInterval: 1.0, repeats: true) { [weak self] _ in
-            Task { @MainActor in
-                self?.tickAutoStartCountdown()
-            }
-        }
-    }
-
-    private func tickAutoStartCountdown() {
-        autoStartCountdown -= 1
-        if autoStartCountdown <= 0 {
-            autoStartTimer?.invalidate()
-            autoStartTimer = nil
-            autoStartCountdown = 0
-            if case .completed = sessionState {
-                startNextSession(isAutoStart: true)
+                timerService.startAutoStartCountdown()
             }
         }
     }

--- a/Oak/Oak/Views/NotchCompanionView+InsideNotch.swift
+++ b/Oak/Oak/Views/NotchCompanionView+InsideNotch.swift
@@ -163,7 +163,7 @@ internal extension NotchCompanionView {
     }
 
     @ViewBuilder
-    private var compactLeadingDisplay: some View {
+    var compactLeadingDisplay: some View {
         if viewModel.canStart {
             presetToggleButton
         } else if viewModel.autoStartCountdown > 0 {

--- a/Oak/Tests/OakTests/US006Tests.swift
+++ b/Oak/Tests/OakTests/US006Tests.swift
@@ -2,6 +2,8 @@ import SwiftUI
 import XCTest
 @testable import Oak
 
+internal typealias ProgressManager = Oak.ProgressManager
+
 private final class TestClock {
     var currentDate: Date
 


### PR DESCRIPTION
## What

Extracted all timer and countdown logic from `FocusSessionViewModel` (415→330 lines) into a dedicated `SessionTimerService` class.

- New: `Oak/Oak/Services/SessionTimerService.swift` — ObservableObject that owns all timer state and lifecycle
- Modified: `Oak/Oak/ViewModels/FocusSessionViewModel.swift` — delegates to the service via DI
- Also fixes two pre-existing build issues on `main`: `ProgressManager` namespace collision and `compactLeadingDisplay` visibility

## Why

`FocusSessionViewModel` was the largest file in the codebase (415 lines), handling session FSM, timer management, auto-start countdown, audio coordination, progress recording, and notifications. Extracting the timer concerns improves separation of concerns and makes the ViewModel easier to reason about and test in isolation.

## How

**SessionTimerService** owns:
- `@Published remainingSeconds`, `autoStartCountdown`, `sessionDuration` — observable state
- `timerFinished` / `autoStartFinished` — `PassthroughSubject` events
- Drift-free countdown using `ceil(sessionEndDate.timeIntervalSinceNow)`
- Full timer lifecycle: `start(seconds:)`, `pause()`, `resume()`, `stop()`

**ViewModel subscribes** via Combine:
- `$remainingSeconds` → updates `sessionState` on each tick
- `$autoStartCountdown` → syncs the published property for views
- `timerFinished` → calls `completeSession()`
- `autoStartFinished` → calls `startNextSession(isAutoStart: true)`

**Backward compatible**: The `timerService` init parameter is optional with a default, so all existing call sites and tests work without changes.

## Checklist

- [x] Tests pass (full suite, 0 failures)
- [x] Lint and format checks pass
- [x] ViewModel reduced from ~415 to ~330 lines
- [x] No breaking changes to public API
