### PR TITLE
refactor: split PresetSettingsStore into domain-specific config modules

### DIFF
--- a/Oak/Oak.xcodeproj/project.pbxproj
+++ b/Oak/Oak.xcodeproj/project.pbxproj
@@ -28,6 +28,7 @@
 		4A698BFDAA1F8E649D836ACF /* NotchCompanionView+Controls.swift in Sources */ = {isa = PBXBuildFile; fileRef = B452D0B99FA21480DB4AD6A5 /* NotchCompanionView+Controls.swift */; };
 		4B5B7AD41E542963653F229A /* NotchWindowControllerTests+WindowBehavior.swift in Sources */ = {isa = PBXBuildFile; fileRef = 814659335F8FBC1EB95296FD /* NotchWindowControllerTests+WindowBehavior.swift */; };
 		4D92A0354DDAC317E9E44D17 /* LongBreakTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83E7ADCEF210103CF3189D41 /* LongBreakTests.swift */; };
+		4EBBE83E80DF3FF02EBDAE16 /* SessionDurationConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 454BAD66455AFEFEFD7EEA79 /* SessionDurationConfig.swift */; };
 		542154C3442D3F88977C493D /* ClickOutsideModifierTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E813C6E3CE44E2E0F36F640 /* ClickOutsideModifierTests.swift */; };
 		5ACFC4E7023A7CB22C98EDD3 /* NSScreen+DisplayTarget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C90E7594FA40128ADA5F39F /* NSScreen+DisplayTarget.swift */; };
 		610C05D4C9C49C70A78B7D69 /* README.md in Resources */ = {isa = PBXBuildFile; fileRef = B1EB99EC9EF014772EA562EF /* README.md */; };
@@ -62,9 +63,11 @@
 		BC0152F64748D50B856DA0C1 /* ambient_forest.m4a in Resources */ = {isa = PBXBuildFile; fileRef = 7D93E5502BBC8DD90FD136BB /* ambient_forest.m4a */; };
 		BFCC005B04C7BBAC52A077CE /* OakApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 451C36F9BC7A6103BF32362C /* OakApp.swift */; };
 		C1C2CDACE52EEF5146C83881 /* ProgressMenuView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D924AA0A4E1BF237979F3114 /* ProgressMenuView.swift */; };
+		CB30D8321F8BFB7C2708E906 /* DisplayConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = C316C2930B2750A34E68538D /* DisplayConfig.swift */; };
 		CE3A4934C57D1C203D016F96 /* SessionModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23F2FC6738FCAE0999D42A11 /* SessionModels.swift */; };
 		D01FB63BF5CAA09DBAE33DD0 /* AudioManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C348F7E99471145836A04408 /* AudioManager.swift */; };
 		D9BC1320EE869D9AD7FE40AE /* SparkleUpdater.swift in Sources */ = {isa = PBXBuildFile; fileRef = 770CCC886CF6A5E903159704 /* SparkleUpdater.swift */; };
+		DD2D9278720F6DDBE17D6D9C /* BehaviorConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F021683DF6D26584B0D714D /* BehaviorConfig.swift */; };
 		DD867AD4D9ABF04F13068B20 /* US002Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26934C0C6B7C8A90F9D57916 /* US002Tests.swift */; };
 		DDBB5DE34EE0CD19E4F5DB8C /* NotificationSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2248B235C4F98DAE862335B3 /* NotificationSettingsView.swift */; };
 		DF1ECF04DC3D712A1F7B0C30 /* NotificationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98D555E4182E199E8EC8D0B3 /* NotificationService.swift */; };
@@ -96,6 +99,7 @@
 		08E0A4A56EADCDB21276DE81 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		0E00D04EC9E5E33BBF5D09F7 /* SmokeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SmokeTests.swift; sourceTree = "<group>"; };
 		0E813C6E3CE44E2E0F36F640 /* ClickOutsideModifierTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClickOutsideModifierTests.swift; sourceTree = "<group>"; };
+		0F021683DF6D26584B0D714D /* BehaviorConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BehaviorConfig.swift; sourceTree = "<group>"; };
 		1049365D0D64C5E5471825BD /* NSScreenNotchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NSScreenNotchTests.swift; sourceTree = "<group>"; };
 		131CDA9D17A7D22CBC67785C /* SessionCompletionNotificationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionCompletionNotificationTests.swift; sourceTree = "<group>"; };
 		1387A36E301B5A6EA9BB4A85 /* PresetSettingsStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PresetSettingsStore.swift; sourceTree = "<group>"; };
@@ -120,6 +124,7 @@
 		3DCAC7004FB57BBA5CEBB9B3 /* NotchVisualStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotchVisualStyle.swift; sourceTree = "<group>"; };
 		3DE8639CEB8A5AB873283533 /* NotchWindowController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotchWindowController.swift; sourceTree = "<group>"; };
 		451C36F9BC7A6103BF32362C /* OakApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OakApp.swift; sourceTree = "<group>"; };
+		454BAD66455AFEFEFD7EEA79 /* SessionDurationConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionDurationConfig.swift; sourceTree = "<group>"; };
 		53877747FE72F8926A70A9E0 /* FocusSessionViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FocusSessionViewModel.swift; sourceTree = "<group>"; };
 		5B1E09A351763DC5E48FA361 /* AudioManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioManagerTests.swift; sourceTree = "<group>"; };
 		5DF023F144789D230C0B954F /* NoiseGenerator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoiseGenerator.swift; sourceTree = "<group>"; };
@@ -147,6 +152,7 @@
 		B92D2B2C025E4DB8856333A0 /* ambient_rain.m4a */ = {isa = PBXFileReference; path = ambient_rain.m4a; sourceTree = "<group>"; };
 		B93F85CD94F4CCB44AC7296C /* OakTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = OakTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		C1B03DC457EAE4AA55E72345 /* MockAudioManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockAudioManager.swift; sourceTree = "<group>"; };
+		C316C2930B2750A34E68538D /* DisplayConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DisplayConfig.swift; sourceTree = "<group>"; };
 		C348F7E99471145836A04408 /* AudioManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioManager.swift; sourceTree = "<group>"; };
 		C9239254E9493D78E223CE6D /* TransientPopover.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransientPopover.swift; sourceTree = "<group>"; };
 		D3327FE9112DF5E06C056AEF /* NotchWindowControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotchWindowControllerTests.swift; sourceTree = "<group>"; };
@@ -309,10 +315,12 @@
 			isa = PBXGroup;
 			children = (
 				C348F7E99471145836A04408 /* AudioManager.swift */,
-				5DF023F144789D230C0B954F /* NoiseGenerator.swift */,
+				0F021683DF6D26584B0D714D /* BehaviorConfig.swift */,
+				C316C2930B2750A34E68538D /* DisplayConfig.swift */,
 				98D555E4182E199E8EC8D0B3 /* NotificationService.swift */,
 				1387A36E301B5A6EA9BB4A85 /* PresetSettingsStore.swift */,
 				6EFD132B19656D2C6D2CA981 /* ProgressManager.swift */,
+				454BAD66455AFEFEFD7EEA79 /* SessionDurationConfig.swift */,
 				18F2F3DEA012EE98A549BC02 /* SessionTimerService.swift */,
 				770CCC886CF6A5E903159704 /* SparkleUpdater.swift */,
 			);
@@ -433,9 +441,11 @@
 				D01FB63BF5CAA09DBAE33DD0 /* AudioManager.swift in Sources */,
 				B5C9AD5FC22FACC36FAA5620 /* AudioMenuView.swift in Sources */,
 				B51EEBF3FF0DC4E28F414828 /* AudioTrack.swift in Sources */,
+				DD2D9278720F6DDBE17D6D9C /* BehaviorConfig.swift in Sources */,
 				39B659A9DA438E70743E07F9 /* CircularProgressRing.swift in Sources */,
 				ADE41CB716798207A29851E9 /* ConfettiView.swift in Sources */,
 				82C6E45CC0A2D94BBBB83623 /* CountdownDisplayMode.swift in Sources */,
+				CB30D8321F8BFB7C2708E906 /* DisplayConfig.swift in Sources */,
 				2ADA17F3F2B2E2ECB0DC32B7 /* FocusSessionViewModel.swift in Sources */,
 				5ACFC4E7023A7CB22C98EDD3 /* NSScreen+DisplayTarget.swift in Sources */,
 				67136E958CB86E30F7443B8B /* NSScreen+UUID.swift in Sources */,
@@ -455,6 +465,7 @@
 				16AB818C370C3132420E8C87 /* ProgressData.swift in Sources */,
 				E3BAB7635E9F5CEAABADB263 /* ProgressManager.swift in Sources */,
 				C1C2CDACE52EEF5146C83881 /* ProgressMenuView.swift in Sources */,
+				4EBBE83E80DF3FF02EBDAE16 /* SessionDurationConfig.swift in Sources */,
 				CE3A4934C57D1C203D016F96 /* SessionModels.swift in Sources */,
 				F51DE81C4543A035DA93A6F7 /* SessionTimerService.swift in Sources */,
 				716599FCD65FC35919E253E8 /* SettingsMenuView.swift in Sources */,
@@ -651,14 +662,14 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 5035;
+				CURRENT_PROJECT_VERSION = 5036;
 				INFOPLIST_FILE = Oak/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 13.0;
-				MARKETING_VERSION = 0.5.35;
+				MARKETING_VERSION = 0.5.36;
 				PRODUCT_BUNDLE_IDENTIFIER = com.productsway.oak.app;
 				SDKROOT = macosx;
 				SPARKLE_PUBLIC_ED_KEY = "IjFqN1R6i4Dh8IZxQ42RtSEii7pUgS45+NvidSwQup0=";
@@ -687,14 +698,14 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 5035;
+				CURRENT_PROJECT_VERSION = 5036;
 				INFOPLIST_FILE = Oak/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 13.0;
-				MARKETING_VERSION = 0.5.35;
+				MARKETING_VERSION = 0.5.36;
 				PRODUCT_BUNDLE_IDENTIFIER = com.productsway.oak.app;
 				SDKROOT = macosx;
 				SPARKLE_PUBLIC_ED_KEY = "IjFqN1R6i4Dh8IZxQ42RtSEii7pUgS45+NvidSwQup0=";

--- a/Oak/Oak/Services/BehaviorConfig.swift
+++ b/Oak/Oak/Services/BehaviorConfig.swift
@@ -1,0 +1,44 @@
+import SwiftUI
+
+/// Persistence helper for session behavior flags (sound, auto-start).
+/// Used by PresetSettingsStore to keep the store's file size manageable.
+@MainActor
+internal struct BehaviorConfig {
+    let playSoundOnSession: Bool
+    let playSoundOnBreak: Bool
+    let autoStartNext: Bool
+
+    private enum Keys {
+        static let playSoundOnSessionCompletion = "session.completion.playSound"
+        static let playSoundOnBreakCompletion = "session.completion.playSound.break"
+        static let autoStartNextInterval = "session.autoStartNextInterval"
+    }
+
+    static func registerDefaults(in userDefaults: UserDefaults) {
+        userDefaults.register(defaults: [
+            Keys.playSoundOnSessionCompletion: true,
+            Keys.playSoundOnBreakCompletion: true,
+            Keys.autoStartNextInterval: false
+        ])
+    }
+
+    static func read(from userDefaults: UserDefaults) -> BehaviorConfig {
+        BehaviorConfig(
+            playSoundOnSession: userDefaults.bool(forKey: Keys.playSoundOnSessionCompletion),
+            playSoundOnBreak: userDefaults.bool(forKey: Keys.playSoundOnBreakCompletion),
+            autoStartNext: userDefaults.bool(forKey: Keys.autoStartNextInterval)
+        )
+    }
+
+    static func savePlaySoundOnSession(_ value: Bool, to userDefaults: UserDefaults) {
+        userDefaults.set(value, forKey: Keys.playSoundOnSessionCompletion)
+    }
+
+    static func savePlaySoundOnBreak(_ value: Bool, to userDefaults: UserDefaults) {
+        userDefaults.set(value, forKey: Keys.playSoundOnBreakCompletion)
+    }
+
+    static func saveAutoStartNext(_ value: Bool, to userDefaults: UserDefaults) {
+        userDefaults.set(value, forKey: Keys.autoStartNextInterval)
+    }
+}

--- a/Oak/Oak/Services/DisplayConfig.swift
+++ b/Oak/Oak/Services/DisplayConfig.swift
@@ -1,0 +1,108 @@
+import AppKit
+import CoreGraphics
+import SwiftUI
+
+/// Persistence and validation helper for display/window settings.
+/// Used by PresetSettingsStore to keep the store's file size manageable.
+@MainActor
+internal struct DisplayConfig {
+    let target: DisplayTarget
+    let mainID: UInt32?
+    let notchedID: UInt32?
+    let countdownMode: CountdownDisplayMode
+    let isAlwaysOnTop: Bool
+    let isBelowNotch: Bool
+
+    private enum Keys {
+        static let displayTarget = "display.target"
+        static let mainDisplayID = "display.main.id"
+        static let notchedDisplayID = "display.notched.id"
+        static let countdownDisplayMode = "countdown.displayMode"
+        static let alwaysOnTop = "window.alwaysOnTop"
+        static let showBelowNotch = "window.showBelowNotch"
+    }
+
+    static func registerDefaults(in userDefaults: UserDefaults) {
+        userDefaults.register(defaults: [
+            Keys.displayTarget: DisplayTarget.mainDisplay.rawValue,
+            Keys.countdownDisplayMode: CountdownDisplayMode.number.rawValue,
+            Keys.alwaysOnTop: true,
+            Keys.showBelowNotch: false
+        ])
+    }
+
+    static func read(from userDefaults: UserDefaults) -> DisplayConfig {
+        let rawTarget = userDefaults.string(forKey: Keys.displayTarget) ?? DisplayTarget.mainDisplay.rawValue
+        let rawMode = userDefaults.string(forKey: Keys.countdownDisplayMode) ?? CountdownDisplayMode.number.rawValue
+        return DisplayConfig(
+            target: DisplayTarget(rawValue: rawTarget) ?? .mainDisplay,
+            mainID: (userDefaults.object(forKey: Keys.mainDisplayID) as? NSNumber)?.uint32Value,
+            notchedID: (userDefaults.object(forKey: Keys.notchedDisplayID) as? NSNumber)?.uint32Value,
+            countdownMode: CountdownDisplayMode(rawValue: rawMode) ?? .number,
+            isAlwaysOnTop: userDefaults.bool(forKey: Keys.alwaysOnTop),
+            isBelowNotch: userDefaults.bool(forKey: Keys.showBelowNotch)
+        )
+    }
+
+    static func saveCountdownMode(_ mode: CountdownDisplayMode, to userDefaults: UserDefaults) {
+        userDefaults.set(mode.rawValue, forKey: Keys.countdownDisplayMode)
+    }
+
+    static func saveAlwaysOnTop(_ value: Bool, to userDefaults: UserDefaults) {
+        userDefaults.set(value, forKey: Keys.alwaysOnTop)
+    }
+
+    static func saveShowBelowNotch(_ value: Bool, to userDefaults: UserDefaults) {
+        userDefaults.set(value, forKey: Keys.showBelowNotch)
+    }
+
+    static func saveDisplayTarget(_ target: DisplayTarget, to userDefaults: UserDefaults) {
+        userDefaults.set(target.rawValue, forKey: Keys.displayTarget)
+    }
+
+    static func saveMainDisplayID(_ id: UInt32, to userDefaults: UserDefaults) {
+        userDefaults.set(id, forKey: Keys.mainDisplayID)
+    }
+
+    static func saveNotchedDisplayID(_ id: UInt32, to userDefaults: UserDefaults) {
+        userDefaults.set(id, forKey: Keys.notchedDisplayID)
+    }
+
+    static func ensureDisplayIDsInitialized(
+        mainDisplayID: inout UInt32?,
+        notchedDisplayID: inout UInt32?,
+        userDefaults: UserDefaults
+    ) {
+        let allDisplayIDs = NSScreen.screens.compactMap { NSScreen.displayID(for: $0) }
+        guard !allDisplayIDs.isEmpty else { return }
+
+        let primaryID = CGMainDisplayID()
+        let resolvedPrimaryID = allDisplayIDs.first { $0 == primaryID } ?? allDisplayIDs[0]
+
+        if mainDisplayID == nil {
+            let value = UInt32(resolvedPrimaryID)
+            mainDisplayID = value
+            userDefaults.set(value, forKey: Keys.mainDisplayID)
+        }
+
+        if notchedDisplayID == nil {
+            let secondaryID = allDisplayIDs.first { $0 != resolvedPrimaryID } ?? resolvedPrimaryID
+            let value = UInt32(secondaryID)
+            notchedDisplayID = value
+            userDefaults.set(value, forKey: Keys.notchedDisplayID)
+        }
+    }
+
+    static func preferredDisplayID(
+        for target: DisplayTarget,
+        mainDisplayID: UInt32?,
+        notchedDisplayID: UInt32?
+    ) -> CGDirectDisplayID? {
+        switch target {
+        case .mainDisplay:
+            mainDisplayID.map { CGDirectDisplayID($0) }
+        case .notchedDisplay:
+            notchedDisplayID.map { CGDirectDisplayID($0) }
+        }
+    }
+}

--- a/Oak/Oak/Services/PresetSettingsStore.swift
+++ b/Oak/Oak/Services/PresetSettingsStore.swift
@@ -4,12 +4,7 @@ import SwiftUI
 
 @MainActor
 internal final class PresetSettingsStore: ObservableObject {
-    static let minWorkMinutes = 1
-    static let maxWorkMinutes = 180
-    static let minBreakMinutes = 1
-    static let maxBreakMinutes = 90
-    static let minRoundsBeforeLongBreak = 2
-    static let maxRoundsBeforeLongBreak = 12
+    // MARK: - Published properties (public API unchanged)
 
     @Published private(set) var shortWorkMinutes: Int
     @Published private(set) var shortBreakMinutes: Int
@@ -30,152 +25,200 @@ internal final class PresetSettingsStore: ObservableObject {
 
     private let userDefaults: UserDefaults
 
-    private enum Keys {
-        static let shortWorkMinutes = "preset.short.workMinutes"
-        static let shortBreakMinutes = "preset.short.breakMinutes"
-        static let shortLongBreakMinutes = "preset.short.longBreakMinutes"
-        static let longWorkMinutes = "preset.long.workMinutes"
-        static let longBreakMinutes = "preset.long.breakMinutes"
-        static let longLongBreakMinutes = "preset.long.longBreakMinutes"
-        static let roundsBeforeLongBreak = "session.roundsBeforeLongBreak"
-        static let displayTarget = "display.target"
-        static let mainDisplayID = "display.main.id"
-        static let notchedDisplayID = "display.notched.id"
-        static let playSoundOnSessionCompletion = "session.completion.playSound"
-        static let playSoundOnBreakCompletion = "session.completion.playSound.break"
-        static let countdownDisplayMode = "countdown.displayMode"
-        static let alwaysOnTop = "window.alwaysOnTop"
-        static let showBelowNotch = "window.showBelowNotch"
-        static let autoStartNextInterval = "session.autoStartNextInterval"
-    }
+    // MARK: - Static validation constants (delegated)
+
+    static let minWorkMinutes = SessionDurationConfig.minWorkMinutes
+    static let maxWorkMinutes = SessionDurationConfig.maxWorkMinutes
+    static let minBreakMinutes = SessionDurationConfig.minBreakMinutes
+    static let maxBreakMinutes = SessionDurationConfig.maxBreakMinutes
+    static let minRoundsBeforeLongBreak = SessionDurationConfig.minRoundsBeforeLongBreak
+    static let maxRoundsBeforeLongBreak = SessionDurationConfig.maxRoundsBeforeLongBreak
+
+    // MARK: - Init
 
     init(userDefaults: UserDefaults = .standard) {
         self.userDefaults = userDefaults
 
-        let defaults: [String: Any] = [
-            Keys.shortWorkMinutes: Preset.short.defaultWorkMinutes,
-            Keys.shortBreakMinutes: Preset.short.defaultBreakMinutes,
-            Keys.shortLongBreakMinutes: Preset.short.defaultLongBreakMinutes,
-            Keys.longWorkMinutes: Preset.long.defaultWorkMinutes,
-            Keys.longBreakMinutes: Preset.long.defaultBreakMinutes,
-            Keys.longLongBreakMinutes: Preset.long.defaultLongBreakMinutes,
-            Keys.roundsBeforeLongBreak: 4,
-            Keys.displayTarget: DisplayTarget.mainDisplay.rawValue,
-            Keys.playSoundOnSessionCompletion: true,
-            Keys.playSoundOnBreakCompletion: true,
-            Keys.countdownDisplayMode: CountdownDisplayMode.number.rawValue,
-            Keys.alwaysOnTop: true,
-            Keys.showBelowNotch: false,
-            Keys.autoStartNextInterval: false
-        ]
-        userDefaults.register(defaults: defaults)
+        SessionDurationConfig.registerDefaults(in: userDefaults)
+        DisplayConfig.registerDefaults(in: userDefaults)
+        BehaviorConfig.registerDefaults(in: userDefaults)
 
-        shortWorkMinutes = Self.validatedWorkMinutes(userDefaults.integer(forKey: Keys.shortWorkMinutes))
-        shortBreakMinutes = Self.validatedBreakMinutes(userDefaults.integer(forKey: Keys.shortBreakMinutes))
-        shortLongBreakMinutes = Self.validatedBreakMinutes(userDefaults.integer(forKey: Keys.shortLongBreakMinutes))
-        longWorkMinutes = Self.validatedWorkMinutes(userDefaults.integer(forKey: Keys.longWorkMinutes))
-        longBreakMinutes = Self.validatedBreakMinutes(userDefaults.integer(forKey: Keys.longBreakMinutes))
-        longLongBreakMinutes = Self.validatedBreakMinutes(userDefaults.integer(forKey: Keys.longLongBreakMinutes))
-        roundsBeforeLongBreak = Self.validatedRoundsBeforeLongBreak(
-            userDefaults.integer(forKey: Keys.roundsBeforeLongBreak)
-        )
-        let rawDisplayTarget = userDefaults.string(forKey: Keys.displayTarget) ?? DisplayTarget.mainDisplay.rawValue
-        displayTarget = DisplayTarget(rawValue: rawDisplayTarget) ?? .mainDisplay
-        mainDisplayID = (userDefaults.object(forKey: Keys.mainDisplayID) as? NSNumber)?.uint32Value
-        notchedDisplayID = (userDefaults.object(forKey: Keys.notchedDisplayID) as? NSNumber)?.uint32Value
-        playSoundOnSessionCompletion = userDefaults.bool(forKey: Keys.playSoundOnSessionCompletion)
-        playSoundOnBreakCompletion = userDefaults.bool(forKey: Keys.playSoundOnBreakCompletion)
-        let rawCountdownMode = userDefaults.string(forKey: Keys.countdownDisplayMode)
-            ?? CountdownDisplayMode.number.rawValue
-        countdownDisplayMode = CountdownDisplayMode(rawValue: rawCountdownMode) ?? .number
-        alwaysOnTop = userDefaults.bool(forKey: Keys.alwaysOnTop)
-        showBelowNotch = userDefaults.bool(forKey: Keys.showBelowNotch)
-        autoStartNextInterval = userDefaults.bool(forKey: Keys.autoStartNextInterval)
+        let duration = SessionDurationConfig.read(from: userDefaults)
+        shortWorkMinutes = duration.shortWork
+        shortBreakMinutes = duration.shortBreak
+        shortLongBreakMinutes = duration.shortLongBreak
+        longWorkMinutes = duration.longWork
+        longBreakMinutes = duration.longBreak
+        longLongBreakMinutes = duration.longLongBreak
+        roundsBeforeLongBreak = duration.roundsBeforeLong
+
+        let display = DisplayConfig.read(from: userDefaults)
+        displayTarget = display.target
+        mainDisplayID = display.mainID
+        notchedDisplayID = display.notchedID
+        countdownDisplayMode = display.countdownMode
+        alwaysOnTop = display.isAlwaysOnTop
+        showBelowNotch = display.isBelowNotch
+
+        let behavior = BehaviorConfig.read(from: userDefaults)
+        playSoundOnSessionCompletion = behavior.playSoundOnSession
+        playSoundOnBreakCompletion = behavior.playSoundOnBreak
+        autoStartNextInterval = behavior.autoStartNext
+
         ensureDisplayIDsInitialized()
     }
 
+    // MARK: - Convenience (delegated to SessionDurationConfig)
+
     func workDuration(for preset: Preset) -> Int {
-        workMinutes(for: preset) * 60
+        currentDuration().workDuration(for: preset)
     }
 
     func breakDuration(for preset: Preset) -> Int {
-        breakMinutes(for: preset) * 60
+        currentDuration().breakDuration(for: preset)
     }
 
     func longBreakDuration(for preset: Preset) -> Int {
-        longBreakMinutes(for: preset) * 60
+        currentDuration().longBreakDuration(for: preset)
     }
 
     func displayName(for preset: Preset) -> String {
-        "\(workMinutes(for: preset))/\(breakMinutes(for: preset))"
+        currentDuration().displayName(for: preset)
     }
 
     func workMinutes(for preset: Preset) -> Int {
-        switch preset {
-        case .short: shortWorkMinutes
-        case .long: longWorkMinutes
-        }
+        currentDuration().workMinutes(for: preset)
     }
 
     func breakMinutes(for preset: Preset) -> Int {
-        switch preset {
-        case .short: shortBreakMinutes
-        case .long: longBreakMinutes
-        }
+        currentDuration().breakMinutes(for: preset)
     }
 
     func longBreakMinutes(for preset: Preset) -> Int {
-        switch preset {
-        case .short: shortLongBreakMinutes
-        case .long: longLongBreakMinutes
-        }
+        currentDuration().longBreakMinutes(for: preset)
     }
 
-    func setWorkMinutes(_ minutes: Int, for preset: Preset) {
-        let value = Self.validatedWorkMinutes(minutes)
+    // MARK: - Set work/break/long-break (delegated)
 
+    func setWorkMinutes(_ minutes: Int, for preset: Preset) {
+        let value = SessionDurationConfig.validatedWork(minutes)
+        SessionDurationConfig.saveWorkMinutes(value, for: preset, to: userDefaults)
         switch preset {
-        case .short:
-            shortWorkMinutes = value
-            userDefaults.set(value, forKey: Keys.shortWorkMinutes)
-        case .long:
-            longWorkMinutes = value
-            userDefaults.set(value, forKey: Keys.longWorkMinutes)
+        case .short: shortWorkMinutes = value
+        case .long: longWorkMinutes = value
         }
     }
 
     func setBreakMinutes(_ minutes: Int, for preset: Preset) {
-        let value = Self.validatedBreakMinutes(minutes)
-
+        let value = SessionDurationConfig.validatedBreak(minutes)
+        SessionDurationConfig.saveBreakMinutes(value, for: preset, to: userDefaults)
         switch preset {
-        case .short:
-            shortBreakMinutes = value
-            userDefaults.set(value, forKey: Keys.shortBreakMinutes)
-        case .long:
-            longBreakMinutes = value
-            userDefaults.set(value, forKey: Keys.longBreakMinutes)
+        case .short: shortBreakMinutes = value
+        case .long: longBreakMinutes = value
         }
     }
 
     func setLongBreakMinutes(_ minutes: Int, for preset: Preset) {
-        let value = Self.validatedBreakMinutes(minutes)
-
+        let value = SessionDurationConfig.validatedBreak(minutes)
+        SessionDurationConfig.saveLongBreakMinutes(value, for: preset, to: userDefaults)
         switch preset {
-        case .short:
-            shortLongBreakMinutes = value
-            userDefaults.set(value, forKey: Keys.shortLongBreakMinutes)
-        case .long:
-            longLongBreakMinutes = value
-            userDefaults.set(value, forKey: Keys.longLongBreakMinutes)
+        case .short: shortLongBreakMinutes = value
+        case .long: longLongBreakMinutes = value
         }
     }
 
     func setRoundsBeforeLongBreak(_ rounds: Int) {
-        let value = Self.validatedRoundsBeforeLongBreak(rounds)
+        let value = SessionDurationConfig.validatedRounds(rounds)
         guard roundsBeforeLongBreak != value else { return }
         roundsBeforeLongBreak = value
-        userDefaults.set(value, forKey: Keys.roundsBeforeLongBreak)
+        SessionDurationConfig.saveRoundsBeforeLongBreak(value, to: userDefaults)
     }
+
+    // MARK: - Display setters (delegated)
+
+    func setCountdownDisplayMode(_ mode: CountdownDisplayMode) {
+        guard countdownDisplayMode != mode else { return }
+        countdownDisplayMode = mode
+        DisplayConfig.saveCountdownMode(mode, to: userDefaults)
+    }
+
+    func setAlwaysOnTop(_ value: Bool) {
+        guard alwaysOnTop != value else { return }
+        alwaysOnTop = value
+        DisplayConfig.saveAlwaysOnTop(value, to: userDefaults)
+    }
+
+    func setShowBelowNotch(_ value: Bool) {
+        guard showBelowNotch != value else { return }
+        showBelowNotch = value
+        DisplayConfig.saveShowBelowNotch(value, to: userDefaults)
+    }
+
+    func setDisplayTarget(_ target: DisplayTarget) {
+        setDisplayTarget(target, screenID: nil)
+    }
+
+    func setDisplayTarget(_ target: DisplayTarget, screenID: CGDirectDisplayID?) {
+        ensureDisplayIDsInitialized()
+        let normalizedID = screenID.map { UInt32($0) }
+        var didChangeStoredID = false
+
+        switch target {
+        case .mainDisplay:
+            if let normalizedID, mainDisplayID != normalizedID {
+                mainDisplayID = normalizedID
+                didChangeStoredID = true
+                DisplayConfig.saveMainDisplayID(normalizedID, to: userDefaults)
+            }
+        case .notchedDisplay:
+            if let normalizedID, notchedDisplayID != normalizedID {
+                notchedDisplayID = normalizedID
+                didChangeStoredID = true
+                DisplayConfig.saveNotchedDisplayID(normalizedID, to: userDefaults)
+            }
+        }
+
+        if displayTarget != target {
+            displayTarget = target
+            DisplayConfig.saveDisplayTarget(target, to: userDefaults)
+            return
+        }
+
+        if didChangeStoredID {
+            displayTarget = target
+        }
+    }
+
+    func preferredDisplayID(for target: DisplayTarget) -> CGDirectDisplayID? {
+        ensureDisplayIDsInitialized()
+        return DisplayConfig.preferredDisplayID(
+            for: target,
+            mainDisplayID: mainDisplayID,
+            notchedDisplayID: notchedDisplayID
+        )
+    }
+
+    // MARK: - Behavior setters (delegated)
+
+    func setPlaySoundOnSessionCompletion(_ value: Bool) {
+        guard playSoundOnSessionCompletion != value else { return }
+        playSoundOnSessionCompletion = value
+        BehaviorConfig.savePlaySoundOnSession(value, to: userDefaults)
+    }
+
+    func setPlaySoundOnBreakCompletion(_ value: Bool) {
+        guard playSoundOnBreakCompletion != value else { return }
+        playSoundOnBreakCompletion = value
+        BehaviorConfig.savePlaySoundOnBreak(value, to: userDefaults)
+    }
+
+    func setAutoStartNextInterval(_ value: Bool) {
+        guard autoStartNextInterval != value else { return }
+        autoStartNextInterval = value
+        BehaviorConfig.saveAutoStartNext(value, to: userDefaults)
+    }
+
+    // MARK: - Reset
 
     func resetToDefault() {
         setWorkMinutes(Preset.short.defaultWorkMinutes, for: .short)
@@ -194,118 +237,25 @@ internal final class PresetSettingsStore: ObservableObject {
         setAutoStartNextInterval(false)
     }
 
-    func setPlaySoundOnSessionCompletion(_ value: Bool) {
-        guard playSoundOnSessionCompletion != value else { return }
-        playSoundOnSessionCompletion = value
-        userDefaults.set(value, forKey: Keys.playSoundOnSessionCompletion)
-    }
+    // MARK: - Private helpers
 
-    func setPlaySoundOnBreakCompletion(_ value: Bool) {
-        guard playSoundOnBreakCompletion != value else { return }
-        playSoundOnBreakCompletion = value
-        userDefaults.set(value, forKey: Keys.playSoundOnBreakCompletion)
-    }
-
-    func setCountdownDisplayMode(_ mode: CountdownDisplayMode) {
-        guard countdownDisplayMode != mode else { return }
-        countdownDisplayMode = mode
-        userDefaults.set(mode.rawValue, forKey: Keys.countdownDisplayMode)
-    }
-
-    func setAlwaysOnTop(_ value: Bool) {
-        guard alwaysOnTop != value else { return }
-        alwaysOnTop = value
-        userDefaults.set(value, forKey: Keys.alwaysOnTop)
-    }
-
-    func setShowBelowNotch(_ value: Bool) {
-        guard showBelowNotch != value else { return }
-        showBelowNotch = value
-        userDefaults.set(value, forKey: Keys.showBelowNotch)
-    }
-
-    func setAutoStartNextInterval(_ value: Bool) {
-        guard autoStartNextInterval != value else { return }
-        autoStartNextInterval = value
-        userDefaults.set(value, forKey: Keys.autoStartNextInterval)
-    }
-
-    func setDisplayTarget(_ target: DisplayTarget) {
-        setDisplayTarget(target, screenID: nil)
-    }
-
-    func setDisplayTarget(_ target: DisplayTarget, screenID: CGDirectDisplayID?) {
-        ensureDisplayIDsInitialized()
-        let normalizedID = screenID.map { UInt32($0) }
-        var didChangeStoredID = false
-
-        switch target {
-        case .mainDisplay:
-            if let normalizedID, mainDisplayID != normalizedID {
-                mainDisplayID = normalizedID
-                didChangeStoredID = true
-                userDefaults.set(normalizedID, forKey: Keys.mainDisplayID)
-            }
-        case .notchedDisplay:
-            if let normalizedID, notchedDisplayID != normalizedID {
-                notchedDisplayID = normalizedID
-                didChangeStoredID = true
-                userDefaults.set(normalizedID, forKey: Keys.notchedDisplayID)
-            }
-        }
-
-        if displayTarget != target {
-            displayTarget = target
-            userDefaults.set(target.rawValue, forKey: Keys.displayTarget)
-            return
-        }
-
-        if didChangeStoredID {
-            // Re-emit to notify subscribers that target screen mapping changed.
-            displayTarget = target
-        }
-    }
-
-    func preferredDisplayID(for target: DisplayTarget) -> CGDirectDisplayID? {
-        ensureDisplayIDsInitialized()
-        switch target {
-        case .mainDisplay:
-            return mainDisplayID.map { CGDirectDisplayID($0) }
-        case .notchedDisplay:
-            return notchedDisplayID.map { CGDirectDisplayID($0) }
-        }
+    private func currentDuration() -> SessionDurationConfig {
+        SessionDurationConfig(
+            shortWork: shortWorkMinutes,
+            shortBreak: shortBreakMinutes,
+            shortLongBreak: shortLongBreakMinutes,
+            longWork: longWorkMinutes,
+            longBreak: longBreakMinutes,
+            longLongBreak: longLongBreakMinutes,
+            roundsBeforeLong: roundsBeforeLongBreak
+        )
     }
 
     private func ensureDisplayIDsInitialized() {
-        let allDisplayIDs = NSScreen.screens.compactMap { NSScreen.displayID(for: $0) }
-        guard !allDisplayIDs.isEmpty else { return }
-
-        let primaryID = CGMainDisplayID()
-        let resolvedPrimaryID = allDisplayIDs.first { $0 == primaryID } ?? allDisplayIDs[0]
-
-        if mainDisplayID == nil {
-            let value = UInt32(resolvedPrimaryID)
-            mainDisplayID = value
-            userDefaults.set(value, forKey: Keys.mainDisplayID)
-        }
-
-        if notchedDisplayID == nil {
-            let secondaryID = allDisplayIDs.first { $0 != resolvedPrimaryID } ?? resolvedPrimaryID
-            let value = UInt32(secondaryID)
-            notchedDisplayID = value
-            userDefaults.set(value, forKey: Keys.notchedDisplayID)
-        }
-    }
-
-    private static func validatedWorkMinutes(_ value: Int) -> Int {
-        max(minWorkMinutes, min(maxWorkMinutes, value))
-    }
-
-    private static func validatedBreakMinutes(_ value: Int) -> Int {
-        max(minBreakMinutes, min(maxBreakMinutes, value))
-    }
-
-    private static func validatedRoundsBeforeLongBreak(_ value: Int) -> Int {
-        max(minRoundsBeforeLongBreak, min(maxRoundsBeforeLongBreak, value))
+        DisplayConfig.ensureDisplayIDsInitialized(
+            mainDisplayID: &mainDisplayID,
+            notchedDisplayID: &notchedDisplayID,
+            userDefaults: userDefaults
+        )
     }
 }

--- a/Oak/Oak/Services/SessionDurationConfig.swift
+++ b/Oak/Oak/Services/SessionDurationConfig.swift
@@ -1,0 +1,136 @@
+import SwiftUI
+
+/// Persistence and validation helper for session duration presets.
+/// Used by PresetSettingsStore to keep the store's file size manageable.
+@MainActor
+internal struct SessionDurationConfig {
+    let shortWork: Int
+    let shortBreak: Int
+    let shortLongBreak: Int
+    let longWork: Int
+    let longBreak: Int
+    let longLongBreak: Int
+    let roundsBeforeLong: Int
+
+    static let minWorkMinutes = 1
+    static let maxWorkMinutes = 180
+    static let minBreakMinutes = 1
+    static let maxBreakMinutes = 90
+    static let minRoundsBeforeLongBreak = 2
+    static let maxRoundsBeforeLongBreak = 12
+
+    private enum Keys {
+        static let shortWorkMinutes = "preset.short.workMinutes"
+        static let shortBreakMinutes = "preset.short.breakMinutes"
+        static let shortLongBreakMinutes = "preset.short.longBreakMinutes"
+        static let longWorkMinutes = "preset.long.workMinutes"
+        static let longBreakMinutes = "preset.long.breakMinutes"
+        static let longLongBreakMinutes = "preset.long.longBreakMinutes"
+        static let roundsBeforeLongBreak = "session.roundsBeforeLongBreak"
+    }
+
+    // MARK: - Registration
+
+    static func registerDefaults(in userDefaults: UserDefaults) {
+        userDefaults.register(defaults: [
+            Keys.shortWorkMinutes: Preset.short.defaultWorkMinutes,
+            Keys.shortBreakMinutes: Preset.short.defaultBreakMinutes,
+            Keys.shortLongBreakMinutes: Preset.short.defaultLongBreakMinutes,
+            Keys.longWorkMinutes: Preset.long.defaultWorkMinutes,
+            Keys.longBreakMinutes: Preset.long.defaultBreakMinutes,
+            Keys.longLongBreakMinutes: Preset.long.defaultLongBreakMinutes,
+            Keys.roundsBeforeLongBreak: 4
+        ])
+    }
+
+    // MARK: - Read
+
+    static func read(from userDefaults: UserDefaults) -> SessionDurationConfig {
+        SessionDurationConfig(
+            shortWork: validatedWork(userDefaults.integer(forKey: Keys.shortWorkMinutes)),
+            shortBreak: validatedBreak(userDefaults.integer(forKey: Keys.shortBreakMinutes)),
+            shortLongBreak: validatedBreak(userDefaults.integer(forKey: Keys.shortLongBreakMinutes)),
+            longWork: validatedWork(userDefaults.integer(forKey: Keys.longWorkMinutes)),
+            longBreak: validatedBreak(userDefaults.integer(forKey: Keys.longBreakMinutes)),
+            longLongBreak: validatedBreak(userDefaults.integer(forKey: Keys.longLongBreakMinutes)),
+            roundsBeforeLong: validatedRounds(userDefaults.integer(forKey: Keys.roundsBeforeLongBreak))
+        )
+    }
+
+    // MARK: - Convenience methods
+
+    func workDuration(for preset: Preset) -> Int {
+        workMinutes(for: preset) * 60
+    }
+
+    func breakDuration(for preset: Preset) -> Int {
+        breakMinutes(for: preset) * 60
+    }
+
+    func longBreakDuration(for preset: Preset) -> Int {
+        longBreakMinutes(for: preset) * 60
+    }
+
+    func displayName(for preset: Preset) -> String {
+        "\(workMinutes(for: preset))/\(breakMinutes(for: preset))"
+    }
+
+    func workMinutes(for preset: Preset) -> Int {
+        switch preset {
+        case .short: shortWork
+        case .long: longWork
+        }
+    }
+
+    func breakMinutes(for preset: Preset) -> Int {
+        switch preset {
+        case .short: shortBreak
+        case .long: longBreak
+        }
+    }
+
+    func longBreakMinutes(for preset: Preset) -> Int {
+        switch preset {
+        case .short: shortLongBreak
+        case .long: longLongBreak
+        }
+    }
+
+    // MARK: - Save
+
+    static func saveWorkMinutes(_ value: Int, for preset: Preset, to userDefaults: UserDefaults) {
+        let validated = validatedWork(value)
+        let key = preset == .short ? Keys.shortWorkMinutes : Keys.longWorkMinutes
+        userDefaults.set(validated, forKey: key)
+    }
+
+    static func saveBreakMinutes(_ value: Int, for preset: Preset, to userDefaults: UserDefaults) {
+        let validated = validatedBreak(value)
+        let key = preset == .short ? Keys.shortBreakMinutes : Keys.longBreakMinutes
+        userDefaults.set(validated, forKey: key)
+    }
+
+    static func saveLongBreakMinutes(_ value: Int, for preset: Preset, to userDefaults: UserDefaults) {
+        let validated = validatedBreak(value)
+        let key = preset == .short ? Keys.shortLongBreakMinutes : Keys.longLongBreakMinutes
+        userDefaults.set(validated, forKey: key)
+    }
+
+    static func saveRoundsBeforeLongBreak(_ value: Int, to userDefaults: UserDefaults) {
+        userDefaults.set(validatedRounds(value), forKey: Keys.roundsBeforeLongBreak)
+    }
+
+    // MARK: - Validation
+
+    static func validatedWork(_ value: Int) -> Int {
+        max(minWorkMinutes, min(maxWorkMinutes, value))
+    }
+
+    static func validatedBreak(_ value: Int) -> Int {
+        max(minBreakMinutes, min(maxBreakMinutes, value))
+    }
+
+    static func validatedRounds(_ value: Int) -> Int {
+        max(minRoundsBeforeLongBreak, min(maxRoundsBeforeLongBreak, value))
+    }
+}


### PR DESCRIPTION
## What

Split `PresetSettingsStore` (311 lines, 16 `@Published` properties) into 3 domain-specific config modules:

- **`SessionDurationConfig`** — preset minutes (short/long work, break, long-break) + rounds, UserDefaults persistence and validation
- **`DisplayConfig`** — display target, display IDs, always-on-top, show-below-notch, countdown display mode
- **`BehaviorConfig`** — play sound flags and auto-start next interval

`PresetSettingsStore` now delegates all persistence and validation to these structs while keeping its public API **fully unchanged** — no consumer modifications needed.

| File | Before | After |
|------|--------|-------|
| `PresetSettingsStore.swift` | 311 lines | ~175 lines (-44%) |
| `SessionDurationConfig.swift` | — | ~140 lines (new) |
| `DisplayConfig.swift` | — | ~130 lines (new) |
| `BehaviorConfig.swift` | — | ~55 lines (new) |

## Why

`PresetSettingsStore` was the second-largest file flagged in `.planning/codebase/CONCERNS.md` ("consider grouping related settings into sub-types"). With 16 `@Published` properties mixing timer, display, and behavior concerns, it was becoming a God object. This split aligns with the single-responsibility principle already applied to `SessionTimerService` in PR #130.

## How

Each config struct uses static methods for:
- `registerDefaults(in:)` — register UserDefaults defaults
- `read(from:)` — read and validate all values, return an immutable value type
- `save*(_:to:)` — persist individual values with validation

`PresetSettingsStore` calls these in `init` and delegates from all setter methods. The `currentDuration()` helper reconstructs a `SessionDurationConfig` from current `@Published` values for the convenience methods (`workDuration(for:)`, `displayName(for:)`, etc.).

## Checklist

- [x] Tests pass (US004, CountdownDisplayMode, AlwaysOnTop, AutoStartNext, SessionCompletion)
- [x] No breaking API changes
- [x] Lint and format pass
