### PR TITLE
refactor: add SessionStateMachine to eliminate state duplication

### DIFF
--- a/Oak/Oak.xcodeproj/project.pbxproj
+++ b/Oak/Oak.xcodeproj/project.pbxproj
@@ -317,6 +317,7 @@
 				C348F7E99471145836A04408 /* AudioManager.swift */,
 				0F021683DF6D26584B0D714D /* BehaviorConfig.swift */,
 				C316C2930B2750A34E68538D /* DisplayConfig.swift */,
+				5DF023F144789D230C0B954F /* NoiseGenerator.swift */,
 				98D555E4182E199E8EC8D0B3 /* NotificationService.swift */,
 				1387A36E301B5A6EA9BB4A85 /* PresetSettingsStore.swift */,
 				6EFD132B19656D2C6D2CA981 /* ProgressManager.swift */,
@@ -662,14 +663,14 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 5036;
+				CURRENT_PROJECT_VERSION = 5038;
 				INFOPLIST_FILE = Oak/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 13.0;
-				MARKETING_VERSION = 0.5.36;
+				MARKETING_VERSION = 0.5.38;
 				PRODUCT_BUNDLE_IDENTIFIER = com.productsway.oak.app;
 				SDKROOT = macosx;
 				SPARKLE_PUBLIC_ED_KEY = "IjFqN1R6i4Dh8IZxQ42RtSEii7pUgS45+NvidSwQup0=";
@@ -698,14 +699,14 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 5036;
+				CURRENT_PROJECT_VERSION = 5038;
 				INFOPLIST_FILE = Oak/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 13.0;
-				MARKETING_VERSION = 0.5.36;
+				MARKETING_VERSION = 0.5.38;
 				PRODUCT_BUNDLE_IDENTIFIER = com.productsway.oak.app;
 				SDKROOT = macosx;
 				SPARKLE_PUBLIC_ED_KEY = "IjFqN1R6i4Dh8IZxQ42RtSEii7pUgS45+NvidSwQup0=";

--- a/Oak/Oak/Models/SessionModels.swift
+++ b/Oak/Oak/Models/SessionModels.swift
@@ -7,6 +7,91 @@ internal enum SessionState: Equatable {
     case completed(isWorkSession: Bool)
 }
 
+// MARK: - SessionStateMachine
+
+/// Value type that encapsulates session state query and transition logic,
+/// eliminating duplicated pattern matching across FocusSessionViewModel.
+@MainActor
+internal enum SessionStateMachine {
+    // MARK: - Queries
+
+    static func isIdle(_ state: SessionState) -> Bool {
+        if case .idle = state {
+            return true
+        }
+        return false
+    }
+
+    static func isRunning(_ state: SessionState) -> Bool {
+        if case .running = state {
+            return true
+        }
+        return false
+    }
+
+    static func isPaused(_ state: SessionState) -> Bool {
+        if case .paused = state {
+            return true
+        }
+        return false
+    }
+
+    static func isCompleted(_ state: SessionState) -> Bool {
+        if case .completed = state {
+            return true
+        }
+        return false
+    }
+
+    static func remainingSeconds(in state: SessionState) -> Int? {
+        switch state {
+        case let .running(remaining, _), let .paused(remaining, _):
+            remaining
+        case .idle, .completed:
+            nil
+        }
+    }
+
+    static func isWorkSession(in state: SessionState) -> Bool? {
+        switch state {
+        case let .running(_, isWork), let .paused(_, isWork), let .completed(isWork):
+            isWork
+        case .idle:
+            nil
+        }
+    }
+
+    // MARK: - Transitions
+
+    static func start(duration: Int, isWorkSession: Bool) -> SessionState {
+        .running(remainingSeconds: duration, isWorkSession: isWorkSession)
+    }
+
+    static func tick(remainingSeconds: Int, from state: SessionState) -> SessionState? {
+        guard case let .running(_, isWork) = state else { return nil }
+        return .running(remainingSeconds: remainingSeconds, isWorkSession: isWork)
+    }
+
+    static func pause(from state: SessionState) -> SessionState? {
+        guard case let .running(remaining, isWork) = state else { return nil }
+        return .paused(remainingSeconds: remaining, isWorkSession: isWork)
+    }
+
+    static func resume(from state: SessionState) -> SessionState? {
+        guard case let .paused(remaining, isWork) = state else { return nil }
+        return .running(remainingSeconds: remaining, isWorkSession: isWork)
+    }
+
+    static func complete(from state: SessionState) -> SessionState? {
+        guard case let .running(_, isWork) = state else { return nil }
+        return .completed(isWorkSession: isWork)
+    }
+
+    static func reset() -> SessionState {
+        .idle
+    }
+}
+
 internal enum Preset: CaseIterable {
     case short
     case long

--- a/Oak/Oak/ViewModels/FocusSessionViewModel.swift
+++ b/Oak/Oak/ViewModels/FocusSessionViewModel.swift
@@ -60,31 +60,19 @@ internal class FocusSessionViewModel: ObservableObject {
     }
 
     var canStart: Bool {
-        if case .idle = sessionState {
-            return true
-        }
-        return false
+        SessionStateMachine.isIdle(sessionState)
     }
 
     var canStartNext: Bool {
-        if case .completed = sessionState {
-            return true
-        }
-        return false
+        SessionStateMachine.isCompleted(sessionState)
     }
 
     var canPause: Bool {
-        if case .running = sessionState {
-            return true
-        }
-        return false
+        SessionStateMachine.isRunning(sessionState)
     }
 
     var canResume: Bool {
-        if case .paused = sessionState {
-            return true
-        }
-        return false
+        SessionStateMachine.isPaused(sessionState)
     }
 
     var displayTime: String {
@@ -128,17 +116,11 @@ internal class FocusSessionViewModel: ObservableObject {
     }
 
     var isPaused: Bool {
-        if case .paused = sessionState {
-            return true
-        }
-        return false
+        SessionStateMachine.isPaused(sessionState)
     }
 
     var isRunning: Bool {
-        if case .running = sessionState {
-            return true
-        }
-        return false
+        SessionStateMachine.isRunning(sessionState)
     }
 
     var currentSessionType: String {
@@ -208,8 +190,10 @@ internal class FocusSessionViewModel: ObservableObject {
     private func setupTimerServiceBindings() {
         timerService.$remainingSeconds
             .sink { [weak self] remaining in
-                guard let self, case .running = self.sessionState, remaining > 0 else { return }
-                sessionState = .running(remainingSeconds: remaining, isWorkSession: isWorkSession)
+                guard let self,
+                      let newState = SessionStateMachine.tick(remainingSeconds: remaining, from: sessionState),
+                      remaining > 0 else { return }
+                sessionState = newState
             }
             .store(in: &timerServiceCancellables)
 
@@ -227,7 +211,7 @@ internal class FocusSessionViewModel: ObservableObject {
 
         timerService.autoStartFinished
             .sink { [weak self] in
-                guard let self, case .completed = self.sessionState else { return }
+                guard let self, SessionStateMachine.isCompleted(self.sessionState) else { return }
                 startNextSession(isAutoStart: true)
             }
             .store(in: &timerServiceCancellables)
@@ -266,25 +250,29 @@ internal extension FocusSessionViewModel {
         isLongBreak = false
         currentSessionStartTime = Date()
         completedRounds = 0
-        sessionState = .running(remainingSeconds: seconds, isWorkSession: isWorkSession)
+        sessionState = SessionStateMachine.start(duration: seconds, isWorkSession: isWorkSession)
         timerService.start(seconds: seconds)
     }
 
     func pauseSession() {
+        guard let newState = SessionStateMachine.pause(from: sessionState) else { return }
         timerService.pause()
         audioManager.pause()
-        sessionState = .paused(remainingSeconds: timerService.remainingSeconds, isWorkSession: isWorkSession)
+        sessionState = newState
     }
 
     func resumeSession() {
+        guard let newState = SessionStateMachine.resume(from: sessionState) else { return }
         audioManager.resume()
-        sessionState = .running(remainingSeconds: timerService.remainingSeconds, isWorkSession: isWorkSession)
+        sessionState = newState
         timerService.resume()
     }
 
     func startNextSession(isAutoStart: Bool = false) {
         resetCompletedRoundsIfNeeded()
-        guard case let .completed(completedWorkSession) = sessionState else {
+        guard let completedWorkSession = SessionStateMachine.isWorkSession(in: sessionState),
+              SessionStateMachine.isCompleted(sessionState)
+        else {
             return
         }
 
@@ -306,7 +294,7 @@ internal extension FocusSessionViewModel {
         }
 
         currentSessionStartTime = Date()
-        sessionState = .running(remainingSeconds: seconds, isWorkSession: isWorkSession)
+        sessionState = SessionStateMachine.start(duration: seconds, isWorkSession: isWorkSession)
 
         if isWorkSession && lastPlayingAudioTrack != .none {
             audioManager.play(track: lastPlayingAudioTrack)
@@ -325,7 +313,7 @@ internal extension FocusSessionViewModel {
         lastPlayingAudioTrack = .none
         wasAutoStarted = false
         audioManager.stop()
-        sessionState = .idle
+        sessionState = SessionStateMachine.reset()
     }
 
     func completeSession() {
@@ -369,7 +357,7 @@ internal extension FocusSessionViewModel {
             completionSoundPlayer.playCompletionSound()
         }
 
-        sessionState = .completed(isWorkSession: isWorkSession)
+        sessionState = SessionStateMachine.complete(from: sessionState) ?? .completed(isWorkSession: isWorkSession)
 
         isSessionComplete = true
 


### PR DESCRIPTION
- Create SessionStateMachine enum with static query methods (isIdle, isRunning, etc.)

- Create transition methods (start, pause, resume, tick, complete, reset)

- Replace all direct sessionState pattern-matching in FocusSessionViewModel

- Replace all direct sessionState assignments with state machine transitions

- Fix pause/resume guard ordering (validate before side effects)

- Fix completeSession to use nil-coalescing fallback for safety

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>