### PR TITLE
refactor: extract window positioning logic into WindowPositioning module

### DIFF
--- a/Oak/Oak.xcodeproj/project.pbxproj
+++ b/Oak/Oak.xcodeproj/project.pbxproj
@@ -28,6 +28,7 @@
 		4A698BFDAA1F8E649D836ACF /* NotchCompanionView+Controls.swift in Sources */ = {isa = PBXBuildFile; fileRef = B452D0B99FA21480DB4AD6A5 /* NotchCompanionView+Controls.swift */; };
 		4B5B7AD41E542963653F229A /* NotchWindowControllerTests+WindowBehavior.swift in Sources */ = {isa = PBXBuildFile; fileRef = 814659335F8FBC1EB95296FD /* NotchWindowControllerTests+WindowBehavior.swift */; };
 		4D92A0354DDAC317E9E44D17 /* LongBreakTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83E7ADCEF210103CF3189D41 /* LongBreakTests.swift */; };
+		4D9BF99164E9F1A8F0F802DE /* WindowPositioning.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAE52F59E069ECD05898D612 /* WindowPositioning.swift */; };
 		4EBBE83E80DF3FF02EBDAE16 /* SessionDurationConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 454BAD66455AFEFEFD7EEA79 /* SessionDurationConfig.swift */; };
 		542154C3442D3F88977C493D /* ClickOutsideModifierTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E813C6E3CE44E2E0F36F640 /* ClickOutsideModifierTests.swift */; };
 		5ACFC4E7023A7CB22C98EDD3 /* NSScreen+DisplayTarget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C90E7594FA40128ADA5F39F /* NSScreen+DisplayTarget.swift */; };
@@ -144,6 +145,7 @@
 		98D555E4182E199E8EC8D0B3 /* NotificationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationService.swift; sourceTree = "<group>"; };
 		A53A901D48495497B38B2A1E /* CountdownDisplayMode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CountdownDisplayMode.swift; sourceTree = "<group>"; };
 		A74529FF7AEFC6AB3D4B6935 /* NotchCompanionViewTests+Layout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NotchCompanionViewTests+Layout.swift"; sourceTree = "<group>"; };
+		AAE52F59E069ECD05898D612 /* WindowPositioning.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowPositioning.swift; sourceTree = "<group>"; };
 		AC19349D6F25778FBE54A06F /* NSScreen+UUID.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSScreen+UUID.swift"; sourceTree = "<group>"; };
 		B1EB99EC9EF014772EA562EF /* README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
 		B452D0B99FA21480DB4AD6A5 /* NotchCompanionView+Controls.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NotchCompanionView+Controls.swift"; sourceTree = "<group>"; };
@@ -299,6 +301,7 @@
 				D9E56FB534D3736A6E1C03BD /* SupportSectionView.swift */,
 				C9239254E9493D78E223CE6D /* TransientPopover.swift */,
 				630A26F2F361CCE214543440 /* UpdateSettingsView.swift */,
+				AAE52F59E069ECD05898D612 /* WindowPositioning.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -317,6 +320,7 @@
 				C348F7E99471145836A04408 /* AudioManager.swift */,
 				0F021683DF6D26584B0D714D /* BehaviorConfig.swift */,
 				C316C2930B2750A34E68538D /* DisplayConfig.swift */,
+				5DF023F144789D230C0B954F /* NoiseGenerator.swift */,
 				98D555E4182E199E8EC8D0B3 /* NotificationService.swift */,
 				1387A36E301B5A6EA9BB4A85 /* PresetSettingsStore.swift */,
 				6EFD132B19656D2C6D2CA981 /* ProgressManager.swift */,
@@ -473,6 +477,7 @@
 				91F4096D77B5684A1251EE01 /* SupportSectionView.swift in Sources */,
 				11949A6E7635E4BC247D1A97 /* TransientPopover.swift in Sources */,
 				1B89D6E392D0EBFBE60F788E /* UpdateSettingsView.swift in Sources */,
+				4D9BF99164E9F1A8F0F802DE /* WindowPositioning.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -662,14 +667,14 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 5036;
+				CURRENT_PROJECT_VERSION = 5038;
 				INFOPLIST_FILE = Oak/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 13.0;
-				MARKETING_VERSION = 0.5.36;
+				MARKETING_VERSION = 0.5.38;
 				PRODUCT_BUNDLE_IDENTIFIER = com.productsway.oak.app;
 				SDKROOT = macosx;
 				SPARKLE_PUBLIC_ED_KEY = "IjFqN1R6i4Dh8IZxQ42RtSEii7pUgS45+NvidSwQup0=";
@@ -698,14 +703,14 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 5036;
+				CURRENT_PROJECT_VERSION = 5038;
 				INFOPLIST_FILE = Oak/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 13.0;
-				MARKETING_VERSION = 0.5.36;
+				MARKETING_VERSION = 0.5.38;
 				PRODUCT_BUNDLE_IDENTIFIER = com.productsway.oak.app;
 				SDKROOT = macosx;
 				SPARKLE_PUBLIC_ED_KEY = "IjFqN1R6i4Dh8IZxQ42RtSEii7pUgS45+NvidSwQup0=";

--- a/Oak/Oak/Views/NotchWindowController.swift
+++ b/Oak/Oak/Views/NotchWindowController.swift
@@ -31,7 +31,7 @@ internal class NotchWindowController: NSWindowController {
             presetSettings: presetSettings,
             notificationService: notificationService
         )
-        let initialWidths = Self.initialWidths(for: presetSettings)
+        let initialWidths = WindowPositioning.initialWidths(for: presetSettings)
 
         let window = NotchWindow(
             width: initialWidths.collapsed,
@@ -74,7 +74,7 @@ internal class NotchWindowController: NSWindowController {
         }
         window.contentView = hostingView
 
-        let initialWidths = Self.initialWidths(for: presetSettings)
+        let initialWidths = WindowPositioning.initialWidths(for: presetSettings)
         window.contentMinSize = NSSize(width: initialWidths.collapsed, height: NotchLayout.height)
         window.contentMaxSize = NSSize(width: initialWidths.expanded, height: NotchLayout.height)
     }
@@ -185,17 +185,24 @@ internal class NotchWindowController: NSWindowController {
             for: activeTarget,
             preferredDisplayID: preferredDisplayID
         )
-        let widths = Self.widths(for: resolvedScreen, showBelowNotch: presetSettings.showBelowNotch)
+        let widths = WindowPositioning.widths(for: resolvedScreen, showBelowNotch: presetSettings.showBelowNotch)
         window.contentMinSize = NSSize(width: widths.collapsed, height: NotchLayout.height)
         window.contentMaxSize = NSSize(width: widths.expanded, height: NotchLayout.height)
 
-        let yPosition = notchYPosition(for: resolvedScreen, alwaysOnTop: presetSettings.alwaysOnTop)
-        let screenFrame = resolvedScreen?.frame ?? .zero
         let targetWidth = expanded ? widths.expanded : widths.collapsed
-        let xPosition = screenFrame.midX - (targetWidth / 2)
-        let frame = NSRect(x: xPosition, y: yPosition, width: targetWidth, height: NotchLayout.height)
+        let frame = WindowPositioning.calculateFrame(
+            screen: resolvedScreen,
+            width: targetWidth,
+            height: NotchLayout.height,
+            alwaysOnTop: presetSettings.alwaysOnTop,
+            showBelowNotch: presetSettings.showBelowNotch
+        )
 
-        guard shouldApplyFrameUpdate(current: window.frame, target: frame, forceReposition: forceReposition) else {
+        guard WindowPositioning.shouldApplyFrameUpdate(
+            current: window.frame,
+            target: frame,
+            forceReposition: forceReposition
+        ) else {
             lastExpandedState = expanded
             return
         }
@@ -204,45 +211,6 @@ internal class NotchWindowController: NSWindowController {
         isApplyingFrameChange = true
         defer { isApplyingFrameChange = false }
         window.setFrame(frame, display: false, animate: false)
-    }
-
-    private func shouldApplyFrameUpdate(current: NSRect, target: NSRect, forceReposition: Bool) -> Bool {
-        if forceReposition {
-            return true
-        }
-
-        return abs(current.minX - target.minX) > 0.5 ||
-            abs(current.minY - target.minY) > 0.5 ||
-            abs(current.width - target.width) > 0.5 ||
-            abs(current.height - target.height) > 0.5
-    }
-
-    private func notchYPosition(for screen: NSScreen?, alwaysOnTop: Bool) -> CGFloat {
-        NotchWindow.calculateYPosition(
-            for: screen,
-            height: NotchLayout.height,
-            alwaysOnTop: alwaysOnTop,
-            showBelowNotch: presetSettings.showBelowNotch
-        )
-    }
-
-    private static func widths(for screen: NSScreen?, showBelowNotch: Bool) -> (collapsed: CGFloat, expanded: CGFloat) {
-        let isInsideNotch = screen?.hasNotch == true && !showBelowNotch
-        if isInsideNotch {
-            return (
-                collapsed: NotchLayout.insideNotchCollapsedWidth,
-                expanded: NotchLayout.insideNotchExpandedWidth
-            )
-        }
-        return (collapsed: NotchLayout.collapsedWidth, expanded: NotchLayout.expandedWidth)
-    }
-
-    private static func initialWidths(for settings: PresetSettingsStore) -> (collapsed: CGFloat, expanded: CGFloat) {
-        let initialScreen = NSScreen.screen(
-            for: settings.displayTarget,
-            preferredDisplayID: settings.preferredDisplayID(for: settings.displayTarget)
-        )
-        return widths(for: initialScreen, showBelowNotch: settings.showBelowNotch)
     }
 }
 
@@ -258,17 +226,16 @@ internal class NotchWindow: NSPanel {
         showBelowNotch: Bool = false
     ) {
         let screen = NSScreen.screen(for: displayTarget, preferredDisplayID: preferredDisplayID)
-        let screenFrame = screen?.frame ?? .zero
-        let xPosition = screenFrame.midX - (width / 2)
-        let yPosition = Self.calculateYPosition(
-            for: screen,
+        let frame = WindowPositioning.calculateFrame(
+            screen: screen,
+            width: width,
             height: height,
             alwaysOnTop: alwaysOnTop,
             showBelowNotch: showBelowNotch
         )
 
         super.init(
-            contentRect: NSRect(x: xPosition, y: yPosition, width: width, height: height),
+            contentRect: frame,
             styleMask: [.borderless, .nonactivatingPanel],
             backing: .buffered,
             defer: false
@@ -280,38 +247,5 @@ internal class NotchWindow: NSPanel {
         isOpaque = false
         hasShadow = false
         ignoresMouseEvents = false
-    }
-
-    /// Calculate Y position for notch-first UI
-    /// - Parameters:
-    ///   - screen: The target screen
-    ///   - height: The window height
-    ///   - alwaysOnTop: Whether the window should be always on top
-    ///   - showBelowNotch: Whether to show below the notch on notched displays
-    /// - Returns: The calculated Y position
-    internal static func calculateYPosition(
-        for screen: NSScreen?,
-        height: CGFloat,
-        alwaysOnTop: Bool,
-        showBelowNotch: Bool = false
-    ) -> CGFloat {
-        guard let screen else { return 0 }
-
-        if screen.hasNotch {
-            if showBelowNotch {
-                return screen.visibleFrame.maxY - height
-            } else {
-                let notchHeight = screen.safeAreaInsets.top
-                if height < notchHeight {
-                    return screen.frame.maxY - notchHeight
-                }
-                return screen.frame.maxY - height
-            }
-        }
-
-        if alwaysOnTop {
-            return screen.visibleFrame.maxY - height
-        }
-        return screen.frame.maxY - height
     }
 }

--- a/Oak/Oak/Views/WindowPositioning.swift
+++ b/Oak/Oak/Views/WindowPositioning.swift
@@ -1,0 +1,90 @@
+import AppKit
+import CoreGraphics
+
+/// Consolidated window positioning calculations extracted from NotchWindowController.
+/// Centralizes frame math, Y-position, width selection, and frame-delta checks.
+@MainActor
+internal enum WindowPositioning {
+    /// Calculate Y position for notch-first UI.
+    static func calculateYPosition(
+        for screen: NSScreen?,
+        height: CGFloat,
+        alwaysOnTop: Bool,
+        showBelowNotch: Bool = false
+    ) -> CGFloat {
+        guard let screen else { return 0 }
+
+        if screen.hasNotch {
+            if showBelowNotch {
+                return screen.visibleFrame.maxY - height
+            } else {
+                let notchHeight = screen.safeAreaInsets.top
+                if height < notchHeight {
+                    return screen.frame.maxY - notchHeight
+                }
+                return screen.frame.maxY - height
+            }
+        }
+
+        if alwaysOnTop {
+            return screen.visibleFrame.maxY - height
+        }
+        return screen.frame.maxY - height
+    }
+
+    /// Determine collapsed and expanded widths for the given screen.
+    static func widths(for screen: NSScreen?, showBelowNotch: Bool) -> (collapsed: CGFloat, expanded: CGFloat) {
+        let isInsideNotch = screen?.hasNotch == true && !showBelowNotch
+        if isInsideNotch {
+            return (
+                collapsed: NotchLayout.insideNotchCollapsedWidth,
+                expanded: NotchLayout.insideNotchExpandedWidth
+            )
+        }
+        return (collapsed: NotchLayout.collapsedWidth, expanded: NotchLayout.expandedWidth)
+    }
+
+    /// Compute initial widths based on the preset settings.
+    static func initialWidths(for settings: PresetSettingsStore) -> (collapsed: CGFloat, expanded: CGFloat) {
+        let initialScreen = NSScreen.screen(
+            for: settings.displayTarget,
+            preferredDisplayID: settings.preferredDisplayID(for: settings.displayTarget)
+        )
+        return widths(for: initialScreen, showBelowNotch: settings.showBelowNotch)
+    }
+
+    /// Build the full window frame for a given state.
+    static func calculateFrame(
+        screen: NSScreen?,
+        width: CGFloat,
+        height: CGFloat,
+        alwaysOnTop: Bool,
+        showBelowNotch: Bool
+    ) -> NSRect {
+        let screenFrame = screen?.frame ?? .zero
+        let xPosition = screenFrame.midX - (width / 2)
+        let yPosition = calculateYPosition(
+            for: screen,
+            height: height,
+            alwaysOnTop: alwaysOnTop,
+            showBelowNotch: showBelowNotch
+        )
+        return NSRect(x: xPosition, y: yPosition, width: width, height: height)
+    }
+
+    /// Check whether a frame update should actually be applied (avoids redundant work).
+    static func shouldApplyFrameUpdate(
+        current: NSRect,
+        target: NSRect,
+        forceReposition: Bool
+    ) -> Bool {
+        if forceReposition {
+            return true
+        }
+
+        return abs(current.minX - target.minX) > 0.5
+            || abs(current.minY - target.minY) > 0.5
+            || abs(current.width - target.width) > 0.5
+            || abs(current.height - target.height) > 0.5
+    }
+}

--- a/Oak/Tests/OakTests/NotchWindowControllerTests+NotchFirstUI.swift
+++ b/Oak/Tests/OakTests/NotchWindowControllerTests+NotchFirstUI.swift
@@ -31,13 +31,13 @@ internal extension NotchWindowControllerTests {
 
         // Calculate all possible valid Y positions for this configuration
         let expectedYPositions = [
-            NotchWindow.calculateYPosition(
+            WindowPositioning.calculateYPosition(
                 for: activeScreen,
                 height: NotchLayout.height,
                 alwaysOnTop: false,
                 showBelowNotch: false
             ),
-            NotchWindow.calculateYPosition(
+            WindowPositioning.calculateYPosition(
                 for: activeScreen,
                 height: NotchLayout.height,
                 alwaysOnTop: false,
@@ -82,7 +82,7 @@ internal extension NotchWindowControllerTests {
         while Date() < endTime {
             if let screen = resolvedScreen {
                 // Use the shared positioning logic to calculate expected position
-                let expectedY = NotchWindow.calculateYPosition(
+                let expectedY = WindowPositioning.calculateYPosition(
                     for: screen,
                     height: NotchLayout.height,
                     alwaysOnTop: presetSettings.alwaysOnTop,


### PR DESCRIPTION
- Create WindowPositioning.swift with calculateYPosition, calculateFrame, widths, initialWidths, shouldApplyFrameUpdate

- Remove old private/static methods from NotchWindowController and NotchWindow

- Update tests to use WindowPositioning.calculateYPosition

- Centralizes all frame math and Y-position calculations

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>