### PR TITLE
refactor: extract PresetEditorView from SettingsMenuView

### DIFF
--- a/Oak/Oak.xcodeproj/project.pbxproj
+++ b/Oak/Oak.xcodeproj/project.pbxproj
@@ -58,6 +58,7 @@
 		B54A841D1308C18C226BF1C0 /* US003Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85C93F37E0AC4AA71C304FDD /* US003Tests.swift */; };
 		B561D0C04BC57500AF7A7EF0 /* NotchLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 164FAFB05B901C05BD1479BF /* NotchLayout.swift */; };
 		B5C9AD5FC22FACC36FAA5620 /* AudioMenuView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3D8E840983307E12ADC1FCF /* AudioMenuView.swift */; };
+		B6CDB0BA711AD583A706B975 /* PresetEditorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA36A47C5BB3764BB7DAD70B /* PresetEditorView.swift */; };
 		B961DAB61BE6B064D46152D3 /* NotchCompanionView+StandardViews.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E581D2529EA9F9B22AEB5DE /* NotchCompanionView+StandardViews.swift */; };
 		B9FD45AD05705636C1173EAC /* NotchWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DE8639CEB8A5AB873283533 /* NotchWindowController.swift */; };
 		BC0152F64748D50B856DA0C1 /* ambient_forest.m4a in Resources */ = {isa = PBXBuildFile; fileRef = 7D93E5502BBC8DD90FD136BB /* ambient_forest.m4a */; };
@@ -163,6 +164,7 @@
 		DCB9EFBE035ED14BBCAAD3D9 /* NotchCompanionViewTests+SessionState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NotchCompanionViewTests+SessionState.swift"; sourceTree = "<group>"; };
 		E43285E82910BB45D9CF9000 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		E680D8D9839B944EB6CB5723 /* NotchWindowControllerTests+NotchFirstUI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NotchWindowControllerTests+NotchFirstUI.swift"; sourceTree = "<group>"; };
+		EA36A47C5BB3764BB7DAD70B /* PresetEditorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PresetEditorView.swift; sourceTree = "<group>"; };
 		F287A617D7BF92425C7BD22A /* ConfettiView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfettiView.swift; sourceTree = "<group>"; };
 		F294622BEE001AE06968C35C /* CountdownDisplayModeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CountdownDisplayModeTests.swift; sourceTree = "<group>"; };
 		F3D8E840983307E12ADC1FCF /* AudioMenuView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioMenuView.swift; sourceTree = "<group>"; };
@@ -294,6 +296,7 @@
 				309530434B76C0BB37A8FA0D /* NotchVisualStyle+Factory.swift */,
 				3DE8639CEB8A5AB873283533 /* NotchWindowController.swift */,
 				2248B235C4F98DAE862335B3 /* NotificationSettingsView.swift */,
+				EA36A47C5BB3764BB7DAD70B /* PresetEditorView.swift */,
 				D924AA0A4E1BF237979F3114 /* ProgressMenuView.swift */,
 				23364F4B016E445E5657BF63 /* SettingsMenuView.swift */,
 				D9E56FB534D3736A6E1C03BD /* SupportSectionView.swift */,
@@ -317,6 +320,7 @@
 				C348F7E99471145836A04408 /* AudioManager.swift */,
 				0F021683DF6D26584B0D714D /* BehaviorConfig.swift */,
 				C316C2930B2750A34E68538D /* DisplayConfig.swift */,
+				5DF023F144789D230C0B954F /* NoiseGenerator.swift */,
 				98D555E4182E199E8EC8D0B3 /* NotificationService.swift */,
 				1387A36E301B5A6EA9BB4A85 /* PresetSettingsStore.swift */,
 				6EFD132B19656D2C6D2CA981 /* ProgressManager.swift */,
@@ -461,6 +465,7 @@
 				DF1ECF04DC3D712A1F7B0C30 /* NotificationService.swift in Sources */,
 				DDBB5DE34EE0CD19E4F5DB8C /* NotificationSettingsView.swift in Sources */,
 				BFCC005B04C7BBAC52A077CE /* OakApp.swift in Sources */,
+				B6CDB0BA711AD583A706B975 /* PresetEditorView.swift in Sources */,
 				1941B67DA3C25D4A42BB7D6D /* PresetSettingsStore.swift in Sources */,
 				16AB818C370C3132420E8C87 /* ProgressData.swift in Sources */,
 				E3BAB7635E9F5CEAABADB263 /* ProgressManager.swift in Sources */,
@@ -662,14 +667,14 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 5036;
+				CURRENT_PROJECT_VERSION = 5038;
 				INFOPLIST_FILE = Oak/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 13.0;
-				MARKETING_VERSION = 0.5.36;
+				MARKETING_VERSION = 0.5.38;
 				PRODUCT_BUNDLE_IDENTIFIER = com.productsway.oak.app;
 				SDKROOT = macosx;
 				SPARKLE_PUBLIC_ED_KEY = "IjFqN1R6i4Dh8IZxQ42RtSEii7pUgS45+NvidSwQup0=";
@@ -698,14 +703,14 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 5036;
+				CURRENT_PROJECT_VERSION = 5038;
 				INFOPLIST_FILE = Oak/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 13.0;
-				MARKETING_VERSION = 0.5.36;
+				MARKETING_VERSION = 0.5.38;
 				PRODUCT_BUNDLE_IDENTIFIER = com.productsway.oak.app;
 				SDKROOT = macosx;
 				SPARKLE_PUBLIC_ED_KEY = "IjFqN1R6i4Dh8IZxQ42RtSEii7pUgS45+NvidSwQup0=";

--- a/Oak/Oak/Views/PresetEditorView.swift
+++ b/Oak/Oak/Views/PresetEditorView.swift
@@ -1,0 +1,82 @@
+import SwiftUI
+
+/// Extracted from SettingsMenuView — renders stepper controls for focus, break, and long-break
+/// minutes within a single preset.
+internal struct PresetEditorView: View {
+    @ObservedObject var presetSettings: PresetSettingsStore
+    let title: String
+    let preset: Preset
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text(title)
+                .font(.system(size: 11, weight: .medium))
+
+            HStack(spacing: 8) {
+                Text("Focus")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+                    .frame(width: 40, alignment: .leading)
+
+                Stepper(
+                    value: workMinutesBinding,
+                    in: PresetSettingsStore.minWorkMinutes ... PresetSettingsStore.maxWorkMinutes
+                ) {
+                    Text("\(presetSettings.workMinutes(for: preset)) min")
+                        .font(.caption)
+                }
+            }
+
+            HStack(spacing: 8) {
+                Text("Break")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+                    .frame(width: 40, alignment: .leading)
+
+                Stepper(
+                    value: breakMinutesBinding,
+                    in: PresetSettingsStore.minBreakMinutes ... PresetSettingsStore.maxBreakMinutes
+                ) {
+                    Text("\(presetSettings.breakMinutes(for: preset)) min")
+                        .font(.caption)
+                }
+            }
+
+            HStack(spacing: 8) {
+                Text("Long")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+                    .frame(width: 40, alignment: .leading)
+
+                Stepper(
+                    value: longBreakMinutesBinding,
+                    in: PresetSettingsStore.minBreakMinutes ... PresetSettingsStore.maxBreakMinutes
+                ) {
+                    Text("\(presetSettings.longBreakMinutes(for: preset)) min")
+                        .font(.caption)
+                }
+            }
+        }
+    }
+
+    private var workMinutesBinding: Binding<Int> {
+        Binding(
+            get: { presetSettings.workMinutes(for: preset) },
+            set: { presetSettings.setWorkMinutes($0, for: preset) }
+        )
+    }
+
+    private var breakMinutesBinding: Binding<Int> {
+        Binding(
+            get: { presetSettings.breakMinutes(for: preset) },
+            set: { presetSettings.setBreakMinutes($0, for: preset) }
+        )
+    }
+
+    private var longBreakMinutesBinding: Binding<Int> {
+        Binding(
+            get: { presetSettings.longBreakMinutes(for: preset) },
+            set: { presetSettings.setLongBreakMinutes($0, for: preset) }
+        )
+    }
+}

--- a/Oak/Oak/Views/SettingsMenuView.swift
+++ b/Oak/Oak/Views/SettingsMenuView.swift
@@ -40,8 +40,16 @@ internal struct SettingsMenuView: View {
             section(title: "Session Presets") {
                 autoStartNextIntervalToggle
                 longBreakCycleEditor
-                presetEditor(title: presetSettings.displayName(for: .short), preset: .short)
-                presetEditor(title: presetSettings.displayName(for: .long), preset: .long)
+                PresetEditorView(
+                    presetSettings: presetSettings,
+                    title: presetSettings.displayName(for: .short),
+                    preset: .short
+                )
+                PresetEditorView(
+                    presetSettings: presetSettings,
+                    title: presetSettings.displayName(for: .long),
+                    preset: .long
+                )
             }
 
             section(title: "Notifications") {
@@ -110,58 +118,6 @@ internal struct SettingsMenuView: View {
                 .font(.system(size: 12, weight: .semibold))
                 .foregroundColor(.primary)
             content()
-        }
-    }
-
-    private func presetEditor(title: String, preset: Preset) -> some View {
-        VStack(alignment: .leading, spacing: 8) {
-            Text(title)
-                .font(.system(size: 11, weight: .medium))
-
-            HStack(spacing: 8) {
-                Text("Focus")
-                    .font(.caption)
-                    .foregroundColor(.secondary)
-                    .frame(width: 40, alignment: .leading)
-
-                Stepper(
-                    value: workMinutesBinding(for: preset),
-                    in: PresetSettingsStore.minWorkMinutes ... PresetSettingsStore.maxWorkMinutes
-                ) {
-                    Text("\(presetSettings.workMinutes(for: preset)) min")
-                        .font(.caption)
-                }
-            }
-
-            HStack(spacing: 8) {
-                Text("Break")
-                    .font(.caption)
-                    .foregroundColor(.secondary)
-                    .frame(width: 40, alignment: .leading)
-
-                Stepper(
-                    value: breakMinutesBinding(for: preset),
-                    in: PresetSettingsStore.minBreakMinutes ... PresetSettingsStore.maxBreakMinutes
-                ) {
-                    Text("\(presetSettings.breakMinutes(for: preset)) min")
-                        .font(.caption)
-                }
-            }
-
-            HStack(spacing: 8) {
-                Text("Long")
-                    .font(.caption)
-                    .foregroundColor(.secondary)
-                    .frame(width: 40, alignment: .leading)
-
-                Stepper(
-                    value: longBreakMinutesBinding(for: preset),
-                    in: PresetSettingsStore.minBreakMinutes ... PresetSettingsStore.maxBreakMinutes
-                ) {
-                    Text("\(presetSettings.longBreakMinutes(for: preset)) min")
-                        .font(.caption)
-                }
-            }
         }
     }
 
@@ -255,27 +211,6 @@ internal struct SettingsMenuView: View {
 }
 
 private extension SettingsMenuView {
-    func workMinutesBinding(for preset: Preset) -> Binding<Int> {
-        Binding(
-            get: { presetSettings.workMinutes(for: preset) },
-            set: { presetSettings.setWorkMinutes($0, for: preset) }
-        )
-    }
-
-    func breakMinutesBinding(for preset: Preset) -> Binding<Int> {
-        Binding(
-            get: { presetSettings.breakMinutes(for: preset) },
-            set: { presetSettings.setBreakMinutes($0, for: preset) }
-        )
-    }
-
-    func longBreakMinutesBinding(for preset: Preset) -> Binding<Int> {
-        Binding(
-            get: { presetSettings.longBreakMinutes(for: preset) },
-            set: { presetSettings.setLongBreakMinutes($0, for: preset) }
-        )
-    }
-
     var displayTargetBinding: Binding<DisplayTarget> {
         Binding(
             get: { selectedDisplayTarget },


### PR DESCRIPTION
- Create standalone PresetEditorView.swift with stepper controls

- Remove 40-line presetEditor wrapper and 3 dead Binding helpers

- Reduce SettingsMenuView by ~50 lines

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added editable session preset controls for Focus, Break, and Long Break durations.
  * Preset settings now use a dedicated editor with validated time ranges.
  * Updated the settings menu to support both short and long session presets.

* **Release**
  * Updated the app version to 0.5.38.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->