### PR TITLE
docs: add keyboard shortcuts and data export/import to user-facing docs

### DIFF
--- a/.planning/codebase/ARCHITECTURE.md
+++ b/.planning/codebase/ARCHITECTURE.md
@@ -1,144 +1,119 @@
-# ARCHITECTURE.md — System Design & Patterns
+# Architecture
 
-## Pattern: MVVM with Protocol-Based DI
+## Pattern: MVVM with @MainActor
 
-Oak follows the **Model-View-ViewModel** pattern with protocol-based dependency injection.
+Oak follows **Model-View-ViewModel** (MVVM) architecture with all observable state pinned to `@MainActor`:
 
 ```
-┌─────────────────────────────────────────┐
-│  OakApp.swift (Entry Point)             │
-│  ┌─────────────────────────────────────┐│
-│  │ AppDelegate (NSApplicationDelegate) ││
-│  │  • Creates NotchWindowController    ││
-│  │  • Creates PresetSettingsStore      ││
-│  │  • Creates NotificationService      ││
-│  │  • Creates SparkleUpdater           ││
-│  └──────────────┬──────────────────────┘│
-└─────────────────┼───────────────────────┘
-                  │
-     ┌────────────▼─────────────┐
-     │  NotchWindowController   │  NSPanel wrapper
-     │  (NSWindowController)    │  • Frame management
-     │                          │  • Display target binding
-     │  Creates:                │  • Screen change observer
-     │  • FocusSessionViewModel │
-     │  • NotchCompanionView    │
-     └────────────┬─────────────┘
-                  │
-     ┌────────────▼─────────────┐
-     │  NotchCompanionView      │  SwiftUI View
-     │  @ObservedObject:        │  • Collapsed/Expanded states
-     │    viewModel              │  • Inside-notch layout variant
-     │    notificationService    │  • Popovers (audio, progress, settings)
-     │    sparkleUpdater         │  • Completion animations (confetti)
-     └────────────┬─────────────┘
-                  │
-     ┌────────────▼─────────────┐
-     │  FocusSessionViewModel   │  @MainActor ObservableObject
-     │                          │  • Session FSM (idle→running→paused→completed)
-     │  Dependencies:           │  • Timer management
-     │  • PresetSettingsStore   │  • Auto-start countdown
-     │  • AudioManager          │  • Progress tracking delegation
-     │  • ProgressManager       │  • Notification & sound triggers
-     │  • NotificationService   │
-     │  • completionSoundPlayer │
-     └──────────────────────────┘
+┌─────────────────────┐
+│   Views (SwiftUI)    │  ← user interaction, layout, rendering
+├─────────────────────┤
+│  ViewModels          │  ← @MainActor, ObservableObject, @Published state
+├─────────────────────┤
+│  Services            │  ← business logic, audio, timers, persistence
+├─────────────────────┤
+│  Models              │  ← Codable structs, enums, value types
+└─────────────────────┘
 ```
+
+## Layer Responsibilities
+
+### Models (`Models/`)
+
+Pure data types — all value types or enums, no business logic:
+
+- `SessionModels.swift` — `SessionState` (FSM enum), `Preset` enum, `SessionType`
+- `ProgressData.swift` — `ProgressData`, `SessionRecord`, `DailyStats`
+- `AudioTrack.swift` — ambient audio track enum
+- `NotchLayout.swift` — layout constants
+- `CountdownDisplayMode.swift` — display mode enum
+
+### Services (`Services/`)
+
+Business logic and system integration — reference types (`class`):
+
+- **`FocusSessionViewModel`** — session lifecycle orchestrator (start/pause/resume/complete/reset)
+- **`AudioManager`** — AVAudioPlayer management, track switching, volume
+- **`ProgressManager`** — session history persistence in UserDefaults, daily stats, streaks
+- **`SessionTimerService`** — Timer-based countdown and auto-start countdown
+- **`PresetSettingsStore`** — all user preferences (durations, display, behavior)
+- **`NotificationService`** — UserNotifications authorization and delivery
+- **`SparkleUpdater`** — SPUStandardUpdaterController wrapper
+- **`KeyboardShortcutService`** — NSEvent local/global keyboard monitoring
+- Configuration services: `SessionDurationConfig`, `DisplayConfig`, `BehaviorConfig`
+- Utility: `NoiseGenerator`
+
+### Views (`Views/`)
+
+SwiftUI views — stateless rendering, `@ObservedObject` bindings to ViewModels:
+
+- `NotchCompanionView` — main notch UI (compact + expanded states)
+- `NotchWindowController` — NSWindowController managing NSPanel lifecycle
+- `SettingsMenuView` — settings panel (presets, display, audio, keyboard, data, updates)
+- Supporting views: `AudioMenuView`, `ProgressMenuView`, `PresetEditorView`, `CircularProgressRing`, `ConfettiView`, etc.
+
+### ViewModels (`ViewModels/`)
+
+- `FocusSessionViewModel` — the single ViewModel bridging all services to views
 
 ## Data Flow
 
 ```
-UserDefaults ←→ PresetSettingsStore ←→ FocusSessionViewModel ←→ NotchCompanionView
-                     ↕ (published properties)              ↕ (display data)
-UserDefaults ←→ ProgressManager ←→ FocusSessionViewModel ←→ ProgressMenuView
-                     ↕
-AVAudioEngine ←→ AudioManager ←→ FocusSessionViewModel
+User Action (click/keypress)
+  → View calls ViewModel method (e.g., startSession())
+    → ViewModel updates @Published state
+      → View re-renders via SwiftUI observation
+
+Timer tick (Timer/Task)
+  → Service publishes new state
+    → ViewModel subscriber receives update
+      → @Published property changes
+        → View re-renders
 ```
 
-## FSM: Session State Machine
+## State Machine
+
+`SessionState` is a finite state machine implemented as an enum with associated values:
 
 ```
-     ┌──────────┐
-     │   IDLE   │──── startSession() ────┐
-     └──────────┘                        │
-          ▲                              ▼
-          │                       ┌──────────┐
-          │ resetSession()        │ RUNNING  │
-          │                       └─────┬────┘
-          │                    pauseSession()│
-          │                              ▼
-          │                       ┌──────────┐
-          │                       │  PAUSED  │
-          │                       └─────┬────┘
-          │                   resumeSession()│
-          │                              ▼
-          │                       ┌──────────┐
-          │           tick() → 0  │ RUNNING  │
-          │           (auto)      └─────┬────┘
-          │                             │ completeSession()
-          │                             ▼
-          │                      ┌───────────┐
-          └────── resetSession() │ COMPLETED │
-                                 └───────────┘
-                                       │
-                          startNextSession() (manual or auto-start)
-                                       │
-                                       ▼
-                                 ┌──────────┐
-                                 │ RUNNING  │ (next interval)
-                                 └──────────┘
+idle → running(seconds, isWork) → paused(seconds, isWork) → running(...)
+                                                    → reset → idle
+running → completed(isWork) → startNext → running(...)
+                           → reset → idle
 ```
 
-## Key Abstractions
+`SessionStateMachine` (introduced in #133) consolidates all state queries and transitions:
 
-### Protocol-Based DI
-
-```swift
-// Session completion notification
-internal protocol SessionCompletionNotifying { ... }
-// Completion sound
-internal protocol SessionCompletionSoundPlaying { ... }
-// Audio engine (for testability)
-internal protocol AudioEngineProtocol { ... }
-```
-
-### @MainActor Enforcement
-
-All `ObservableObject` classes, ViewModels, and window controllers are annotated `@MainActor`:
-
-- `FocusSessionViewModel`
-- `AudioManager`
-- `NotificationService`
-- `PresetSettingsStore`
-- `ProgressManager`
-- `SparkleUpdater`
-- `NotchWindowController`
-
-### Published State
-
-State flows through `@Published` properties:
-
-- `sessionState: SessionState` — FSM state with associated values
-- `selectedPreset: Preset` — short (25/5) or long (50/10)
-- `isSessionComplete: Bool` — triggers confetti & animations
-- `autoStartCountdown: Int` — 10-second countdown for auto-start
-- `completedRounds: Int` — tracks rounds before long break trigger
+- `isIdle()`, `isRunning()`, `isPaused()`, `isCompleted()`
+- `start()`, `pause()`, `resume()`, `complete()`, `reset()`, `tick()`
 
 ## Entry Points
 
-| Entry | File | Role |
-| --- | --- | --- |
-| `@main` | `Oak/OakApp.swift` | SwiftUI App lifecycle |
-| `AppDelegate` | `Oak/OakApp.swift` | NSApplicationDelegate, window creation |
-| `NotchWindowController` | `Oak/Oak/Views/NotchWindowController.swift` | Window lifecycle, frame management |
+1. **`OakApp.swift`** — `@main` App struct + `AppDelegate` (NSApplicationDelegate)
+   - `applicationDidFinishLaunching` — creates `NotchWindowController`, sets `activationPolicy(.accessory)`
+2. **`NotchWindowController.swift`** — owns `NSPanel`, hosts `NotchCompanionView` via `NSHostingView`
 
-## Window Architecture
+## Dependency Injection
 
-`NotchWindow` is an `NSPanel` with:
+Services use protocol-based DI with optional default parameters:
 
-- `.borderless` + `.nonactivatingPanel` style mask
-- `.canJoinAllSpaces` + `.stationary` collection behavior
-- `level`: `.statusBar` (always on top) or `.floating` (normal)
-- Transparent background, no shadow
-- Dynamic width: collapsed (compact) vs expanded (full controls)
-- Y-position calculated based on notch presence and `showBelowNotch` setting
+```swift
+init(
+    audioManager: AudioManager? = nil,
+    progressManager: ProgressManager? = nil,
+    notificationService: any SessionCompletionNotifying,
+    ...
+)
+```
+
+Tests inject protocol-based mocks (`MockAudioManager`, `MockNotificationService`) and isolated `UserDefaults` suites.
+
+## Key Abstractions
+
+| Abstraction                     | Type     | Purpose                                            |
+| ------------------------------- | -------- | -------------------------------------------------- |
+| `SessionCompletionNotifying`    | protocol | Decouple notification delivery from ViewModel      |
+| `SessionCompletionSoundPlaying` | protocol | Decouple sound playback (beep) from ViewModel      |
+| `SessionTimerServicing`         | protocol | Decouple timer implementation from ViewModel       |
+| `WindowPositioning`             | enum     | Consolidate frame math and Y-position calculations |
+| `SessionStateMachine`           | enum     | Pure state transition logic                        |

--- a/.planning/codebase/CONCERNS.md
+++ b/.planning/codebase/CONCERNS.md
@@ -1,73 +1,79 @@
-# CONCERNS — Oak Technical Concerns
+# Technical Concerns
 
-## Known Issues
+## Resolved (Recent PRs)
 
-### 1. SwiftLint Crashes Without Full Xcode
+| Concern | Resolution | PR |
+| --- | --- | --- |
+| Large `FocusSessionViewModel` (was 415 lines) | Extracted `SessionTimerService` (108 lines) + `SessionStateMachine` | #130, #133 |
+| `AudioManager` too large (374 lines) | Extracted `NoiseGenerator.swift` | #129 |
+| `PresetSettingsStore` monolithic | Split into `SessionDurationConfig`, `DisplayConfig`, `BehaviorConfig` | #132 |
+| Thin test files (Confetti, ClickOutside, Smoke) | Added meaningful assertions | #131 |
+| NotchCompanionView fragmented (4 files) | Merged extensions from 4→3 files | #135 |
+| Duplicated window positioning logic | Extracted `WindowPositioning` enum | #137 |
+| `SettingsMenuView` large (was ~390 lines) | Extracted `PresetEditorView` | #138 |
+| Keyboard shortcuts missing | Added `KeyboardShortcutService` — Space/Escape | #142 |
+| No progress data export | Added JSON/CSV export, JSON import | #141 |
 
-`SourceKittenFramework/library_wrapper.swift:58: Fatal error: Loading sourcekitdInProc.framework failed`
+## Active Concerns
 
-- **Impact**: Lint checks fail in CI or dev environments without full Xcode
-- **Workaround**: None — requires full Xcode installation
-- **File**: `.swiftlint.yml`
+### 1. Test Suite Performance
 
-### 2. Building Requires Full Xcode
+- **Issue**: Full test suite times out at 600 seconds on CI; `build-and-test` checks are frequently cancelled
+- **Location**: All test files under `Tests/OakTests/`
+- **Impact**: CI feedback loop is unreliable; PRs show `UNSTABLE` merge state due to cancelled checks
+- **Recommendation**: Profile tests with Instruments, identify slowest tests, optimize or split test target
 
-`xcodebuild` (used by all `just` commands: build, test, check, etc.) requires a full Xcode installation. Command Line Tools are insufficient.
+### 2. Large File: NotchCompanionView (351 lines)
 
-- **Impact**: Cannot build, test, or typecheck from terminal environments with only Command Line Tools
-- **Workaround**: Open in Xcode IDE and build from there
+- **Location**: `Views/NotchCompanionView.swift`
+- **Concern**: Below 500-line warn threshold but contains controls, layout, completion animation, and popover handling in one struct
+- **Recommendation**: Extract popover presentation logic or completion animation into separate components
 
-## Code Quality
+### 3. Large File: AudioManager (328 lines)
 
-### Positive
+- **Location**: `Services/AudioManager.swift`
+- **Concern**: Still contains noise generation, track management, playback control, and volume logic after NoiseGenerator extraction
+- **Recommendation**: Consider extracting audio track management or playback strategies
 
-- ✅ All `weak self` usages are correctly applied in escaping closures
-- ✅ All `deinit` methods properly invalidate timers or cancel tasks
-- ✅ `@MainActor` consistently applied across UI/service declarations
-- ✅ Protocol-based DI enables clean test mocking
-- ✅ UserDefaults isolated per test with unique suite names
-- ✅ No `print()` statements found (logged via `os.log` or removed)
-- ✅ No TODO, FIXME, HACK, or XXX comments in source code
-- ✅ `fatalError` only in 1 standard location (`init(coder:)` in `NotchWindowController`)
+### 4. Large File: SettingsMenuView (341 lines)
 
-### Resolved (v0.5.35+)
+- **Location**: `Views/SettingsMenuView.swift`
+- **Concern**: Accumulated Display, Session Presets, Notifications, Keyboard, Data, Updates, and Support sections
+- **Recommendation**: Further extract the Display and Session Presets sections into sub-views
 
-| Concern | Resolution |
-| --- | --- |
-| FocusSessionViewModel (415 lines) | Timer logic extracted to `SessionTimerService` (PR #130); state logic extracted to `SessionStateMachine` (PR #133); now ~330 lines |
-| View extension proliferation (4 files) | Merged `+Controls` into main file, reduced from 4 to 3 files (PR #135) |
-| PresetSettingsStore (311 lines, 16 props) | Split into `SessionDurationConfig`, `DisplayConfig`, `BehaviorConfig` modules (PR #132); now ~175 lines |
-| Thin test files (ConfettiView, ClickOutside, Smoke) | Expanded with integration-level tests (PR #129, #131) |
-| NoiseGenerator in AudioManager | Extracted to `Services/NoiseGenerator.swift` (PR #129) |
-| Window positioning logic scattered | Extracted into `WindowPositioning` module (PR #137) |
-| Pre-existing format issues | Resolved in v0.5.34 |
-| SettingsMenuView preset editor (50 lines) | Extracted to `PresetEditorView` standalone component |
+### 5. Silence on Import/Export Failure
 
-### Watch Points
+- **Location**: `Views/SettingsMenuView.swift` — `exportJSON()`, `exportCSV()`, `importData()`
+- **Concern**: File I/O failures are silently swallowed (`try?`). Users get no feedback on success or failure.
+- **Recommendation**: Add NSAlert for both success and failure paths
 
-- **SettingsMenuView**: Reduced from 334 to ~280 lines after extracting `PresetEditorView`. Still moderately large but well-structured with section helpers.
-- **No UI/integration tests**: All tests are unit tests. No automated UI testing for notch positioning, window behavior, or visual states.
+### 6. No Session Deduplication on Import
 
-## Security
+- **Location**: `Services/ProgressManager.swift` — `importRecords(from:)`
+- **Concern**: Importing the same file twice creates duplicate `SessionRecord` entries (different UUIDs)
+- **Recommendation**: Deduplicate by matching `startTime` + `type` instead of blind `append(contentsOf:)`
 
-- App is sandboxed (`Oak.entitlements`)
-- No network requests except Sparkle updates (HTTPS appcast)
-- No user data collection or telemetry
-- UserDefaults for local-only storage — no PII or secrets stored
+### 7. Keyboard Shortcut Customization UI
 
-## Performance
+- **Issue**: #67 requested configurable shortcut keys; current implementation shows read-only badges
+- **Location**: `Views/SettingsMenuView.swift` — keyboard section
+- **Recommendation**: Add key-recording UI to let users customize shortcut bindings
 
-- Ambient audio uses `AVAudioEngine` with standby for smooth playback
-- Noise generation (`NoiseGenerator`) is computationally light (per-sample math)
-- Timer-based countdown at 1s intervals — low overhead
-- No known memory leaks (all Combine subscriptions properly managed with `AnyCancellable` + `deinit`)
+### 8. Global Hotkey Permission Check
 
-## MVP Constraints (Enforced)
+- **Location**: `Services/KeyboardShortcutService.swift` — `startGlobalMonitor()`
+- **Concern**: Global hotkey monitoring requires Accessibility permission; no proactive check or guidance
+- **Recommendation**: Check `AXIsProcessTrusted()` and prompt user when global hotkeys are enabled
 
-| Constraint                             | Status |
-| -------------------------------------- | ------ |
-| Presets: 25/5 and 50/10 (configurable) | ✅     |
-| Notch-only UI, no menu bar fallback    | ✅     |
-| No global keyboard shortcuts           | ✅     |
-| Auto-start next: OFF by default        | ✅     |
-| Built-in audio only, no cloud sync     | ✅     |
+### 9. Row-Level UI for Today's Timeline
+
+- **Issue**: #66 — detailed session timeline with per-session stats
+- **Location**: `Views/ProgressMenuView.swift`
+- **Recommendation**: Add expandable rows showing session type, exact duration, start/end times
+
+## Watch Items
+
+- **NotchCompanionView file growth** — currently 351 lines, approaching 500-line warn threshold
+- **Swift 6 concurrency readiness** — `@MainActor` usage is consistent but some deinit patterns access MainActor-isolated properties
+- **Test isolation** — some tests may share UserDefaults if suite names collide (UUID-based names prevent this)
+- **macOS version dependencies** — conditional `@available` checks for 13.0+ and 13.3+ features (safe area regions)

--- a/.planning/codebase/CONVENTIONS.md
+++ b/.planning/codebase/CONVENTIONS.md
@@ -1,157 +1,104 @@
-# CONVENTIONS.md — Coding Standards & Patterns
+# Coding Conventions
 
-## Formatting
+## Swift Style
 
-| Rule             | Value                          |
-| ---------------- | ------------------------------ |
-| Indentation      | 4 spaces                       |
-| Line length      | 120 (warn), 150 (error)        |
-| File length      | 500 lines (warn), 1000 (error) |
-| Function body    | 50 lines (warn)                |
-| Trailing newline | Required                       |
-| Documentation    | `///` for public/internal APIs |
+### Access Control
 
-## Naming
+- Explicit `internal` keyword on all declarations (enforced by SwiftLint `explicit_top_level_acl`)
+- `private` for encapsulated state, `private(set)` for read-only published properties
+- `public` only where needed (rare — mostly testable internals)
 
-| Element | Convention | Example |
-| --- | --- | --- |
-| Types | PascalCase | `FocusSessionViewModel` |
-| Functions/Vars | camelCase | `startSession()`, `displayTime` |
-| Constants (instance) | lowerCamelCase | `horizontalPadding` |
-| Constants (static) | PascalCase | `minWorkMinutes` |
-| Booleans | `is`/`has`/`should`/`can` prefix | `isWorkSession`, `canStart`, `shouldUseLongBreak` |
-| Protocols (capability) | `*ing` suffix | `SessionCompletionNotifying` |
-| Protocols (role) | `*Protocol` suffix | `AudioEngineProtocol` |
-| UserDefaults keys | dot-notation strings | `"preset.short.workMinutes"` |
+### Naming
 
-## Access Control
+- **Types**: PascalCase (`FocusSessionViewModel`, `SessionState`)
+- **Functions/Variables**: camelCase (`startSession`, `displayTime`)
+- **Constants**: lowerCamelCase for instances, PascalCase for statics
+- **Booleans**: `is`/`has`/`should` prefix (`isWorkSession`, `canStart`, `shouldUseLongBreak`)
+- **Protocols**: `*ing` suffix for capabilities (`SessionCompletionNotifying`, `SessionCompletionSoundPlaying`)
 
-- `internal` keyword is **explicit** on ALL declarations (SwiftLint `explicit_top_level_acl`)
-- `private` for internal state, `private(set)` for read-only published
-- `private enum Keys` with static strings for UserDefaults keys
+### Imports
 
-## Imports
-
-```swift
-// Order: Foundation → Combine → SwiftUI/AppKit → Apple frameworks
-import Foundation
-import Combine
-import SwiftUI
-import AVFoundation
-```
-
-- No blank lines between imports
-- One blank line between types
+- **Order**: Foundation → Combine → SwiftUI/AppKit → Apple frameworks → `@testable import Oak`
+- **Grouping**: `testable-bottom` (testable imports last)
+- No blank lines between imports, one blank line between types
 - Remove unused imports (analyzer rule)
 
-## ViewModel & ObservableObject Patterns
+### Formatting
 
-```swift
-@MainActor
-internal class FocusSessionViewModel: ObservableObject {
-    @Published var sessionState: SessionState = .idle
-    @Published var selectedPreset: Preset = .short
-    @Published private(set) var completedRounds: Int = 0
+- **Indent**: 4 spaces
+- **Line length**: 120 (warn), 150 (error)
+- **Trailing newline**: Required
+- **Documentation**: `///` for public/internal APIs
+- **File length**: Warn at 500 lines, error at 1000
+- **Function body**: Warn at 50 lines
 
-    // Protocol-based DI
-    let audioManager: AudioManager
-    let notificationService: any SessionCompletionNotifying
-    let completionSoundPlayer: any SessionCompletionSoundPlaying
+### SwiftLint Opt-in Rules
 
-    init(
-        presetSettings: PresetSettingsStore,
-        audioManager: AudioManager? = nil,
-        notificationService: any SessionCompletionNotifying,
-        completionSoundPlayer: (any SessionCompletionSoundPlaying)? = nil,
-        currentDate: @escaping () -> Date = Date.init
-    ) { ... }
-}
-```
+`explicit_init`, `explicit_top_level_acl`, `trailing_closure`, `first_where`, `toggle_bool`, `modifier_order`, `vertical_parameter_alignment_on_call`, `closure_spacing`, `empty_count`, `sorted_first_last`, `redundant_type_annotation`, `yoda_condition`, `unneeded_parentheses_in_closure_argument`
 
-- Always `@MainActor` on `ObservableObject` classes
-- Use `any Protocol` for type-erased DI
-- Provide default parameter values for optional dependencies
-- Forward `objectWillChange` from child stores via Combine
+### SwiftFormat
 
-## State Machine Pattern
+- 4-space indent, 120 max width, `wraparguments before-first`
+- `self` removal, `isEmpty` enforcement
+- Blank lines between scopes, sorted imports
 
-```swift
-// Enum with associated values for FSM
-internal enum SessionState: Equatable {
-    case idle
-    case running(remainingSeconds: Int, isWorkSession: Bool)
-    case paused(remainingSeconds: Int, isWorkSession: Bool)
-    case completed(isWorkSession: Bool)
-}
+## Architecture Conventions
 
-// State checks via if case
-if case .idle = sessionState { ... }
-if case let .running(remaining, isWork) = sessionState { ... }
-```
+### @MainActor
 
-## Error Handling & Logging
+- All `ObservableObject` classes must be `@MainActor` or use `@MainActor`-annotated methods
+- All ViewModels must be `@MainActor`
+- Services that don't need UI isolation can omit `@MainActor` if they dispatch properly
+- **CRITICAL**: Keep `@MainActor` on `ObservableObject` with `@Published`
 
-- `os.Logger` for production logging (subsystem: `com.productsway.oak.app`)
-- No `print()` statements (SwiftLint warns)
-- `guard` early returns preferred over nested `if`
-- `Result` for async operations
-- `do/catch` with logged errors for audio operations
+### State Management
 
-## Memory & Concurrency
+- Enums with associated values for FSMs (`SessionState`)
+- `if case` for state checks
+- Computed properties for derived state (`displayTime`, `canPause`, `progressPercentage`)
 
-```swift
-// [weak self] in ALL escaping closures
-timer = Timer.scheduledTimer(withTimeInterval: 1.0, repeats: true) { [weak self] _ in
-    Task { @MainActor in
-        self?.tick()
-    }
-}
-
-// Always invalidate() timers in deinit
-deinit {
-    timer?.invalidate()
-    autoStartTimer?.invalidate()
-}
-```
+### Memory & Concurrency
 
 - `[weak self]` in all escaping closures
-- `Timer.invalidate()` in `deinit`
-- `Task { @MainActor in ... }` to return to main actor
-- `AnyCancellable` for Combine subscriptions, cancelled on deinit
+- Always `invalidate()` timers in `deinit`
+- Wrap timer callbacks: `Task { @MainActor in self?.tick() }`
+- Use `AnyCancellable` for Combine subscriptions
+- Cancel subscriptions in `deinit`
 
-## View Update Safety
+### View Update Safety
 
 ```swift
-// ❌ Wrong - publishes from view update synchronously
+// ❌ Wrong — publishes from view update
 .onChange(of: value) { newValue in viewModel.update(newValue) }
 
-// ✅ Correct - async dispatch
+// ✅ Correct — async dispatch
 .onChange(of: value) { newValue in
     DispatchQueue.main.async { viewModel.update(newValue) }
 }
 ```
 
-## Dependency Injection
+### Error Handling
 
-Protocol-based DI is used throughout:
+- Use `Result` for async operations
+- Prefer `guard`/early returns over nested `if`
+- **Logging**: `os.log` for production, `print()` only for debug (SwiftLint warns on `print()`)
 
-- `SessionCompletionNotifying` — notification delivery (mocked in tests)
-- `SessionCompletionSoundPlaying` — completion sound (mocked in tests)
-- `AudioEngineProtocol` — audio engine (mocked in tests)
+### Dependency Injection
 
-Default implementations provided via init parameters for production use.
+- Protocol-based mocks for testing
+- Optional parameters with defaults for production code:
+  ```swift
+  init(audioManager: AudioManager? = nil, ...)
+  ```
+- Use `any Protocol` syntax for type-erasure
 
-## UserDefaults
+## Testing Conventions
 
-- Keys stored in `private enum Keys { static let ... }`
-- `userDefaults.register(defaults:)` for all keys at init
-- Validated getters with clamped ranges (`validatedWorkMinutes`, `validatedBreakMinutes`)
-- Guard against no-op writes: `guard currentValue != newValue else { return }`
+- `@MainActor` on test classes
+- `@testable import Oak` for internal access
+- Isolate `UserDefaults` with unique suite names
+- Always `cleanup()` and remove persistent domains in `tearDown()`
 
-## SwiftUI View Conventions
+## Commit Style
 
-- Extract subviews as `private var someView: some View` computed properties
-- Use `@ObservedObject` for injected dependencies
-- `@State` for local UI state only
-- Popover-based menus (audio, progress, settings)
-- Completion animations: `.spring(response: 0.3, dampingFraction: 0.7)`
+`type(scope): description` — types: `feat`, `fix`, `refactor`, `test`, `docs`, `chore`

--- a/.planning/codebase/INTEGRATIONS.md
+++ b/.planning/codebase/INTEGRATIONS.md
@@ -1,44 +1,43 @@
-# INTEGRATIONS.md — External Services & APIs
+# External Integrations
 
 ## Sparkle Update Framework
 
-- **Service**: [Sparkle 2](https://sparkle-project.org/) (self-hosted)
-- **Purpose**: In-app update distribution
-- **Files**: `Oak/Oak/Services/SparkleUpdater.swift`
-- **Configuration**:
-  - Public Ed25519 key: `IjFqN1R6i4Dh8IZxQ42RtSEii7pUgS45+NvidSwQup0=` (in `project.yml`)
-  - Feed URL: `https://raw.githubusercontent.com/jellydn/oak/main/appcast.xml` (in `Info.plist`)
-  - Update check interval: 86,400 seconds (24 hours)
-  - `SUEnableAutomaticChecks: true`
-- **Protocols**: `SPUUpdaterDelegate`
-- **Network entitlement**: `com.apple.security.network.client` (required for Sparkle feed fetching)
+- **Package**: `sparkle-project/Sparkle` v2.9.4
+- **Purpose**: In-app software updates via appcast
+- **Integration point**: `Services/SparkleUpdater.swift` — wraps `SPUStandardUpdaterController`
+- **Public key**: EdDSA (`IjFqN1R6i4Dh8IZxQ42RtSEii7pUgS45+NvidSwQup0=`)
+- **Appcast URL**: `https://raw.githubusercontent.com/jellydn/oak/main/appcast.xml`
+- **Check interval**: 86400 seconds (daily)
+- **Settings UI**: `Views/UpdateSettingsView.swift` — manual check button, auto-check toggle
 
-## UserNotifications Framework
+## Apple Notification Center
 
-- **Service**: Apple `UserNotifications` (system-level, local)
-- **Purpose**: Local notification delivery for session completions
-- **Files**: `Oak/Oak/Services/NotificationService.swift`
-- **Authorization**: Requests `.alert` + `.sound` authorization; status is refreshed on app activation
-- **Deep link**: Uses `x-apple.systempreferences:` URLs to open Notification Settings when denied
-- **Protocol**: `SessionCompletionNotifying`
+- **Framework**: `UserNotifications`
+- **Purpose**: Local notifications for session completion
+- **Integration point**: `Services/NotificationService.swift`
+- **Requires**: User-granted notification permission (requested from Settings)
+- **Settings UI**: `Views/NotificationSettingsView.swift` — permission request button, sound toggle
 
-## UserDefaults
+## Apple System Frameworks (Direct API)
 
-- **Service**: Apple `UserDefaults` (system-level, local)
-- **Purpose**: Persistent settings storage
-- **Files**: `Oak/Oak/Services/PresetSettingsStore.swift`, `Oak/Oak/Services/ProgressManager.swift`
-- **Keys**: Prefixed with `preset.`, `display.`, `session.`, `window.`, `countdown.` domains
-- **Default registration**: `userDefaults.register(defaults:)` for all keys
-- **Validation**: Clamped value ranges for work/break minutes and rounds
+| Framework | Usage | Key Files |
+| --- | --- | --- |
+| **AppKit** | Window management, NSEvent monitoring, file dialogs | `NotchWindowController.swift`, `KeyboardShortcutService.swift`, `TransientPopover.swift` |
+| **AVFoundation** | Ambient audio playback | `AudioManager.swift` |
+| **CoreGraphics** | Display identification | `NSScreen+DisplayTarget.swift`, `DisplayConfig.swift` |
+| **UserDefaults** | Local persistence (progress, settings, audio prefs) | `ProgressManager.swift`, `PresetSettingsStore.swift` |
 
-## GitHub (CI/CD & Distribution)
+## Local Persistence Only
 
-- **CI**: GitHub Actions on `macos-26` runners (`.github/workflows/ci.yml`)
-  - Lint: `swiftlint lint --strict`
-  - Build & Test: `xcodebuild` with `CODE_SIGNING_ALLOWED=NO`
-- **Release**: Automated appcast + Homebrew cask updates (`.github/workflows/release.yml`)
-- **Homebrew Cask**: `Casks/oak.rb` for `brew install` distribution
+- No cloud sync, no remote database, no account system
+- All data stored in `UserDefaults`:
+  - `progressHistory` — `[ProgressData]` as JSON
+  - `keyboardShortcutConfig` — `KeyboardShortcutConfig` as JSON
+  - Various settings keys managed by `SessionDurationConfig`, `DisplayConfig`, `BehaviorConfig`
 
-## No External Backend
+## No External APIs
 
-Oak is a fully local macOS app with no cloud backend, no user accounts, no analytics, and no telemetry. All data stays on-device in `UserDefaults`.
+- No REST APIs called
+- No WebSocket connections
+- No third-party analytics or crash reporting
+- Network used only for Sparkle appcast fetching (outbound HTTP)

--- a/.planning/codebase/STACK.md
+++ b/.planning/codebase/STACK.md
@@ -1,71 +1,58 @@
-# STACK.md — Technology Stack
+# Technology Stack
 
-## Language & Runtime
+## Languages
 
-| Layer | Technology | Version |
-| --- | --- | --- |
-| Language | Swift | 5.9+ |
-| Platform | macOS | 13.0+ (Apple Silicon preferred) |
-| Xcode | Xcode 16+ (`project.yml` references xcodeVersion 17.0) |
+- **Swift 5.9+** — primary language, concurrency via `async/await`, `@MainActor`, `Task`
 
-## UI Framework
+## Runtime & Platform
 
-| Component       | Technology                                                      |
-| --------------- | --------------------------------------------------------------- |
-| UI Framework    | SwiftUI                                                         |
-| AppKit Bridging | `NSViewRepresentable`, `NSHostingView`, `NSPanel`               |
-| Window Type     | `NSPanel` with `.borderless` + `.nonactivatingPanel` style mask |
-| Notch Detection | `NSScreen.safeAreaInsets.top` for physical notch detection      |
+- **macOS 13.0+** (Ventura) — deployment target
+- **Apple Silicon** (arm64) — primary target; Intel (x86_64) supported via universal binary
+- **Xcode 17.0** — development toolchain
 
-## Core Frameworks
+## Frameworks & Libraries
+
+### Apple Frameworks
 
 | Framework | Usage |
 | --- | --- |
-| **Combine** | Reactive bindings (`@Published`, `AnyCancellable`, `.sink`) |
-| **AVFoundation** | Audio playback (bundled `.m4a` files + procedural noise generation via `AVAudioSourceNode`) |
+| **SwiftUI** | All UI components (notch companion, settings, menus, popovers) |
+| **AppKit** | Window management (`NSPanel`, `NSWindowController`), NSEvent monitoring, `NSSavePanel`/`NSOpenPanel`, `NSSound` |
+| **Combine** | `ObservableObject`, `@Published`, `AnyCancellable`, `PassthroughSubject` — reactive data flow |
+| **AVFoundation** | Ambient audio playback (`AVAudioPlayer`) |
+| **Foundation** | Codable persistence (`JSONEncoder`/`JSONDecoder`), `UserDefaults`, `Timer`, date handling |
+| **CoreGraphics** | Display ID management (`CGDirectDisplayID`) |
 | **UserNotifications** | Local notification delivery for session completion |
-| **AppKit** | Window management, `NSScreen` extensions, `NSSound.beep()` |
-| **CoreGraphics** | Display ID resolution (`CGMainDisplayID()`) |
-| **Foundation** | `Timer`, `UserDefaults`, `os.Logger` |
+| **os.log** | Structured logging (`Logger`) |
 
-## Third-Party Dependencies
+### Third-Party Dependencies
 
-| Package | Version | Usage |
+| Package | Version | Purpose |
 | --- | --- | --- |
-| [Sparkle](https://github.com/sparkle-project/Sparkle) | 2.9.4 | In-app update checking and distribution (`SPUUpdaterDelegate`) |
+| **[Sparkle](https://github.com/sparkle-project/Sparkle)** | 2.9.4 | In-app update framework (auto-update checks, release channels) |
 
-## Build System
+## Build & Tooling
 
 | Tool | Purpose |
 | --- | --- |
-| [XcodeGen](https://github.com/yonaskolb/XcodeGen) | Project generation from `project.yml` |
-| [just](https://github.com/casey/just) | Task runner (`just build`, `just test`, `just lint`) |
-| xcodebuild | CI builds (GitHub Actions on `macos-26` runners) |
+| **XcodeGen** (`project.yml`) | Project file generation — single source of truth for targets, sources, dependencies |
+| **SwiftLint** (`.swiftlint.yml`) | Static analysis — line length (120/150), function body (50/100), file length (500/1000), naming rules |
+| **SwiftFormat** (`.swiftformat`) | Code formatting — 4-space indent, 120 max width, sorted imports, `self` removal |
+| **just** (`justfile`) | Task runner — `just build`, `just test`, `just lint`, `just format`, `just dev` |
+| **GitHub Actions** (`.github/workflows/`) | CI — `ci.yml` (build+test+lint), `release.yml`, `auto-release.yml`, `update-appcast.yml`, `deploy-pages.yml` |
+| **Prettier** (`.prettierrc`) | Markdown/YAML formatting |
 
-## Code Quality
+## Configuration
 
-| Tool | Configuration |
-| --- | --- |
-| SwiftLint | `.swiftlint.yml` (opt-in rules: `explicit_init`, `trailing_closure`, `empty_count`, etc.) |
-| SwiftFormat | `.swiftformat` (indent: 4, maxwidth: 120, `wraparguments before-first`) |
+- **`project.yml`** — XcodeGen config: targets, sources, bundle ID (`com.productsway.oak.app`), version (`0.5.40`), build (`5040`)
+- **`Info.plist`** — `LSUIElement = true` (accessory app, no Dock icon), Sparkle feed URL + public EdDSA key
+- **`Oak.entitlements`** — `com.apple.security.network.client` (outbound networking for Sparkle updates)
+- **`appcast.xml`** — Sparkle appcast feed for update distribution
+- **`prek.toml`** — Additional project metadata
 
-## Configuration Files
+## App Architecture
 
-| File | Purpose |
-| --- | --- |
-| `Oak/project.yml` | XcodeGen project definition (targets, dependencies, build settings) |
-| `Oak/Oak/Info.plist` | App metadata, Sparkle feed URL, `LSUIElement = true` |
-| `Oak/Oak/Oak.entitlements` | `com.apple.security.network.client` (outbound networking for Sparkle) |
-| `justfile` | Task automation commands |
-| `.swiftlint.yml` | Lint rule configuration |
-| `.swiftformat` | Formatter rule configuration |
-| `appcast.xml` | Sparkle appcast for update distribution |
-
-## CI/CD
-
-| Provider | Platform | File |
-| --- | --- | --- |
-| GitHub Actions | `macos-26` runner | `.github/workflows/ci.yml` |
-| Lint | `swiftlint lint --strict` | CI job |
-| Build & Test | `xcodebuild build` + `xcodebuild test` (unsigned, no code signing) | CI job |
-| Release | Sparkle appcast update + Homebrew cask | `.github/workflows/release.yml` |
+- **Type**: macOS accessory app (`.accessory` activation policy, `LSUIElement`)
+- **UI Pattern**: Notch-only companion, no standard main window
+- **Bundle ID**: `com.productsway.oak.app`
+- **Current Version**: 0.5.40 (build 5040)

--- a/.planning/codebase/STRUCTURE.md
+++ b/.planning/codebase/STRUCTURE.md
@@ -1,125 +1,124 @@
-# STRUCTURE.md — Directory Layout & Organization
-
-## Top-Level Layout
+# Directory Structure
 
 ```
-Oak/                           # XcodeGen root (project.yml lives here)
-├── Oak/                       # Main app target sources
-│   ├── OakApp.swift          # @main entry point + AppDelegate
-│   ├── Models/               # Data models, enums, protocols
-│   ├── Views/                # SwiftUI Views + NSWindowController
-│   ├── ViewModels/           # @MainActor ObservableObject classes
-│   ├── Services/             # Business logic, audio, persistence
-│   ├── Extensions/           # NSScreen and other extensions
-│   ├── Resources/            # Assets catalog, bundled sounds
-│   ├── Info.plist            # App metadata & Sparkle config
-│   └── Oak.entitlements      # Sandbox entitlements
-├── Tests/                    # Unit test target
-│   └── OakTests/             # All test files
-├── project.yml               # XcodeGen project definition
-└── Oak.xcodeproj/            # Generated Xcode project (do not edit)
+Oak/
+├── Oak/                          # Main application target
+│   ├── OakApp.swift              # @main entry point + AppDelegate
+│   ├── Info.plist                # App metadata, LSUIElement, Sparkle config
+│   ├── Oak.entitlements          # Network client entitlement
+│   │
+│   ├── Models/                   # Data models (value types, enums)
+│   │   ├── SessionModels.swift   # SessionState (FSM), Preset, SessionType
+│   │   ├── ProgressData.swift    # ProgressData, SessionRecord, DailyStats
+│   │   ├── AudioTrack.swift      # Ambient audio track enum
+│   │   ├── NotchLayout.swift     # Layout constants (height, sizing)
+│   │   └── CountdownDisplayMode.swift
+│   │
+│   ├── ViewModels/               # ViewModels (@MainActor, ObservableObject)
+│   │   └── FocusSessionViewModel.swift  # 373 lines — session lifecycle
+│   │
+│   ├── Views/                    # SwiftUI Views
+│   │   ├── NotchCompanionView.swift          # 351 lines — main notch UI
+│   │   ├── NotchCompanionView+StandardViews.swift  # 282 lines
+│   │   ├── NotchCompanionView+InsideNotch.swift     # 259 lines
+│   │   ├── NotchWindowController.swift      # 255 lines — NSPanel management
+│   │   ├── WindowPositioning.swift          # 90 lines — frame math
+│   │   ├── SettingsMenuView.swift           # 341 lines — settings panel
+│   │   ├── PresetEditorView.swift           # 82 lines — stepper controls
+│   │   ├── ProgressMenuView.swift           # 140 lines — daily stats
+│   │   ├── AudioMenuView.swift              # Ambient track picker
+│   │   ├── CircularProgressRing.swift       # Progress indicator
+│   │   ├── ConfettiView.swift               # Session completion effect
+│   │   ├── TransientPopover.swift           # Click-outside dismiss
+│   │   ├── NotificationSettingsView.swift   # Notification permission UI
+│   │   ├── UpdateSettingsView.swift         # Sparkle update controls
+│   │   ├── SupportSectionView.swift         # Links and support info
+│   │   ├── NotchVisualStyle.swift           # Visual theming
+│   │   └── NotchVisualStyle+Factory.swift   # Style factory
+│   │
+│   ├── Services/                 # Business logic & persistence
+│   │   ├── AudioManager.swift             # 328 lines — AVAudioPlayer
+│   │   ├── ProgressManager.swift          # 163 lines — UserDefaults persistence
+│   │   ├── PresetSettingsStore.swift      # 261 lines — all settings
+│   │   ├── SessionTimerService.swift      # 108 lines — Timer-based countdown
+│   │   ├── NotificationService.swift      # 101 lines — UserNotifications
+│   │   ├── SparkleUpdater.swift           # 219 lines — update framework
+│   │   ├── KeyboardShortcutService.swift  # 258 lines — NSEvent monitoring
+│   │   ├── NoiseGenerator.swift           # White/brown noise generator
+│   │   ├── SessionDurationConfig.swift    # 136 lines — duration settings
+│   │   ├── DisplayConfig.swift            # 108 lines — display settings
+│   │   └── BehaviorConfig.swift           # Behavior settings
+│   │
+│   ├── Extensions/               # Swift extensions
+│   │   ├── NSScreen+UUID.swift            # Display UUID tracking
+│   │   └── NSScreen+DisplayTarget.swift   # Screen matching & notch detection
+│   │
+│   └── Resources/                # Assets
+│       ├── Assets.xcassets/      # App icon
+│       └── Sounds/               # Built-in ambient audio (m4a)
+│           ├── ambient_rain.m4a
+│           ├── ambient_forest.m4a
+│           ├── ambient_cafe.m4a
+│           ├── ambient_lofi.m4a
+│           └── ambient_brown_noise.m4a
+│
+├── Tests/OakTests/               # 29 test files
+│   ├── US001Tests.swift through US006Tests.swift  # Feature-level tests
+│   ├── NotchCompanionViewTests.swift (+Layout, +SessionState)
+│   ├── NotchWindowControllerTests.swift (+NotchWindow, +WindowBehavior, +NotchFirstUI)
+│   ├── AudioManagerTests.swift, AudioPersistenceTests.swift
+│   ├── AccessibilityTests.swift
+│   ├── ConfettiViewTests.swift, ClickOutsideModifierTests.swift
+│   ├── CountdownDisplayModeTests.swift
+│   ├── AlwaysOnTopTests.swift
+│   ├── LongBreakTests.swift
+│   ├── AutoStartNextIntervalTests.swift
+│   ├── NotificationTests.swift, SessionCompletionNotificationTests.swift
+│   ├── SparkleUpdaterTests.swift, AppcastVersionParserTests.swift
+│   ├── NSScreenNotchTests.swift
+│   ├── SmokeTests.swift
+│   └── MockAudioManager.swift
+│
+├── project.yml                  # XcodeGen configuration
+├── justfile                     # Task runner
+├── .swiftlint.yml               # Lint rules
+├── .swiftformat                 # Format rules
+├── appcast.xml                  # Sparkle release feed
+├── CHANGELOG.md                 # Release history
+├── README.md                    # Project readme
+├── DEVELOPMENT.md               # Developer setup guide
+├── CONTEXT.md                   # Codebase context
+├── TROUBLESHOOTING.md           # Common issues
+├── AGENTS.md                    # AI agent guidelines
+├── RELEASES.md                  # Release notes
+├── LICENSE                      # MIT license
+│
+├── .planning/codebase/          # Codebase map (these docs)
+├── .github/workflows/           # CI/CD pipelines
+├── scripts/release/             # Release asset scripts
+├── docs/                        # GitHub Pages site
+├── Casks/                       # Homebrew cask formula
+└── tasks/                       # PRD documents
 ```
 
-## Source Files by Directory
+## File Line Counts (Largest 10)
 
-### `Oak/Oak/Models/` — Data Models & Enums
-
-| File | Lines | Contents |
-| --- | --- | --- |
-| `SessionModels.swift` | 69 | `SessionState` enum (FSM), `Preset` enum, `DisplayTarget` enum |
-| `ProgressData.swift` | 59 | `SessionType`, `SessionRecord`, `DailyStats` structs (Codable) |
-| `AudioTrack.swift` | 45 | `AudioTrack` enum (rain, forest, cafe, brownNoise, lofi, none) |
-| `NotchLayout.swift` | 29 | `NotchLayout` enum (width/height constants) |
-| `CountdownDisplayMode.swift` | 15 | `CountdownDisplayMode` enum (number, circleRing) |
-
-### `Oak/Oak/Views/` — UI Layer
-
-| File | Lines | Role |
-| --- | --- | --- |
-| `NotchWindowController.swift` | 317 | Window lifecycle, frame management, screen change handling |
-| `SettingsMenuView.swift` | 334 | Settings popover (preset config, display, notifications, updates) |
-| `NotchCompanionView+StandardViews.swift` | 285 | Expanded/collapsed view layouts for non-notch displays |
-| `NotchCompanionView+InsideNotch.swift` | 257 | Layout variants for inside-physical-notch displays |
-| `NotchCompanionView+Controls.swift` | 189 | Audio/Progress/Settings buttons, timer display, session controls |
-| `NotchCompanionView.swift` | 158 | Root view composing all layouts, popovers, completion animations |
-| `ProgressMenuView.swift` | 140 | Progress & streak display popover |
-| `TransientPopover.swift` | 77 | Click-outside-to-dismiss popover modifier |
-| `NotificationSettingsView.swift` | 67 | Notification permission management in Settings |
-| `AudioMenuView.swift` | 66 | Audio track selection & volume control popover |
-| `ConfettiView.swift` | 65 | Confetti animation on work session completion |
-| `UpdateSettingsView.swift` | 41 | Sparkle update check & auto-download settings |
-| `CircularProgressRing.swift` | 39 | Circular progress indicator for countdown |
-| `NotchVisualStyle+Factory.swift` | 22 | Factory for visual style based on inside-notch state |
-| `NotchVisualStyle.swift` | 15 | Visual style constants (colors, corner radius) |
-| `SupportSectionView.swift` | 19 | Support/feedback links in Settings |
-
-### `Oak/Oak/ViewModels/` — View Models
-
-| File | Lines | Role |
-| --- | --- | --- |
-| `FocusSessionViewModel.swift` | 415 | Core session management, FSM transitions, timer, auto-start |
-
-### `Oak/Oak/Services/` — Business Logic
-
-| File                        | Lines | Role                                                    |
-| --------------------------- | ----- | ------------------------------------------------------- |
-| `AudioManager.swift`        | 374   | Audio playback (bundled + procedural), `NoiseGenerator` |
-| `PresetSettingsStore.swift` | 311   | UserDefaults-backed settings with validation            |
-| `SparkleUpdater.swift`      | 219   | Sparkle integration, `AppcastVersionParser`             |
-| `ProgressManager.swift`     | 163   | Daily stats, streaks, session recording                 |
-| `NotificationService.swift` | 101   | Local notification authorization & delivery             |
-
-### `Oak/Oak/Extensions/` — Swift Extensions
-
-| File                           | Lines | Role                                              |
-| ------------------------------ | ----- | ------------------------------------------------- |
-| `NSScreen+UUID.swift`          | 82    | Screen UUID caching, notch detection (`hasNotch`) |
-| `NSScreen+DisplayTarget.swift` | 62    | Screen resolution for display targets             |
-
-### `Oak/Tests/OakTests/` — Test Suite
-
-| File | Lines | Focus |
-| --- | --- | --- |
-| `US006Tests.swift` | ~270 | Progress tracking & streaks |
-| `LongBreakTests.swift` | ~300 | Long break logic and round tracking |
-| `US004Tests.swift` | ~190 | Audio selection, volume, display target |
-| `SessionCompletionNotificationTests.swift` | ~220 | Notification & sound on session completion |
-| `NotchWindowControllerTests+WindowBehavior.swift` | ~180 | Window expand/collapse, reposition |
-| `AudioPersistenceTests.swift` | ~245 | Audio track persistence across sessions |
-| `AutoStartNextIntervalTests.swift` | ~260 | Auto-start countdown logic |
-| `US003Tests.swift` | ~100 | Pause/resume session |
-| `US001Tests.swift` | ~75 | Notch visibility, session start |
-| `US002Tests.swift` | ~50 | Preset selection |
-| `US005Tests.swift` | ~80 | Session completion state |
-| `NotchCompanionViewTests.swift` | ~50 | View initialization |
-| `NotchCompanionViewTests+SessionState.swift` | ~110 | State transitions |
-| `NotchCompanionViewTests+Layout.swift` | ~30 | Layout tests |
-| `NotchWindowControllerTests.swift` | ~60 | Window creation |
-| `NotchWindowControllerTests+NotchWindow.swift` | ~20 | Window positioning |
-| `NotchWindowControllerTests+NotchFirstUI.swift` | ~110 | Notch-first positioning |
-| `AlwaysOnTopTests.swift` | ~100 | Always-on-top setting |
-| `CountdownDisplayModeTests.swift` | ~60 | Display mode persistence |
-| `AudioManagerTests.swift` | ~130 | Audio engine tests |
-| `NotificationTests.swift` | ~35 | Notification service |
-| `AccessibilityTests.swift` | ~30 | Accessibility |
-| `SparkleUpdaterTests.swift` | ~10 | Sparkle updater |
-| `ConfettiViewTests.swift` | ~15 | Confetti view |
-| `ClickOutsideModifierTests.swift` | ~15 | Click-outside dismiss |
-| `AppcastVersionParserTests.swift` | ~10 | Appcast version parsing |
-| `NSScreenNotchTests.swift` | ~10 | Notch detection |
-| `SmokeTests.swift` | ~5 | Sanity check |
-| `MockAudioManager.swift` | N/A | Audio manager mock |
+| File                                     | Lines |
+| ---------------------------------------- | ----- |
+| `FocusSessionViewModel.swift`            | 373   |
+| `NotchCompanionView.swift`               | 351   |
+| `SettingsMenuView.swift`                 | 341   |
+| `AudioManager.swift`                     | 328   |
+| `NotchCompanionView+StandardViews.swift` | 282   |
+| `PresetSettingsStore.swift`              | 261   |
+| `NotchCompanionView+InsideNotch.swift`   | 259   |
+| `KeyboardShortcutService.swift`          | 258   |
+| `NotchWindowController.swift`            | 255   |
+| `SparkleUpdater.swift`                   | 219   |
 
 ## Naming Conventions
 
-| Pattern         | Example                                              |
-| --------------- | ---------------------------------------------------- |
-| View files      | `NotchCompanionView.swift`, `SettingsMenuView.swift` |
-| View extensions | `NotchCompanionView+InsideNotch.swift`               |
-| ViewModel files | `FocusSessionViewModel.swift`                        |
-| Service files   | `AudioManager.swift`, `ProgressManager.swift`        |
-| Model files     | `SessionModels.swift`, `ProgressData.swift`          |
-| Extension files | `NSScreen+UUID.swift`                                |
-| Test files      | `US001Tests.swift`, `AudioManagerTests.swift`        |
-| Test extensions | `NotchWindowControllerTests+WindowBehavior.swift`    |
-| Protocol names  | `SessionCompletionNotifying`, `AudioEngineProtocol`  |
+- **Files**: PascalCase, mirroring primary type name
+- **Extensions**: `TypeName+Feature.swift` (e.g., `NotchCompanionView+Controls.swift`)
+- **Tests**: `{Feature}Tests.swift` or `{Feature}Tests+{Aspect}.swift`
+- **Directories**: Models, Views, ViewModels, Services, Extensions, Resources

--- a/.planning/codebase/TESTING.md
+++ b/.planning/codebase/TESTING.md
@@ -1,152 +1,94 @@
-# TESTING.md — Test Structure & Practices
+# Testing
 
 ## Framework
 
-| Aspect    | Detail                                                         |
-| --------- | -------------------------------------------------------------- |
-| Framework | XCTest                                                         |
-| Runner    | `xcodebuild test` via `just test`                              |
-| Target    | `OakTests` (bundle.unit-test, `GENERATE_INFOPLIST_FILE: true`) |
-| CI        | GitHub Actions, `macos-26` runner, unsigned builds             |
+- **XCTest** — Apple's native testing framework
+- All tests annotated with `@MainActor`
+- `@testable import Oak` for internal API access
 
-## Test File Organization
+## Test Structure
 
-```
-Tests/OakTests/
-├── US001Tests.swift                            # Notch visibility, session start
-├── US002Tests.swift                            # Preset selection
-├── US003Tests.swift                            # Pause/resume session
-├── US004Tests.swift                            # Audio, volume, display target
-├── US005Tests.swift                            # Session completion states
-├── US006Tests.swift                            # Progress tracking & streaks
-├── SessionCompletionNotificationTests.swift    # Notifications & sounds
-├── AudioManagerTests.swift                     # Audio engine
-├── AudioPersistenceTests.swift                 # Audio track persistence
-├── AutoStartNextIntervalTests.swift            # Auto-start countdown
-├── CountdownDisplayModeTests.swift             # Display mode persistence
-├── LongBreakTests.swift                        # Long break logic
-├── AlwaysOnTopTests.swift                      # Always-on-top setting
-├── NotchCompanionViewTests.swift               # View initialization
-├── NotchCompanionViewTests+SessionState.swift  # State transitions
-├── NotchCompanionViewTests+Layout.swift        # Layout tests
-├── NotchWindowControllerTests.swift            # Window creation
-├── NotchWindowControllerTests+WindowBehavior.swift  # Expand/collapse
-├── NotchWindowControllerTests+NotchWindow.swift     # Window features
-├── NotchWindowControllerTests+NotchFirstUI.swift    # Notch-first positioning
-├── NotificationTests.swift                     # Notification service
-├── AccessibilityTests.swift                    # Accessibility
-├── SparkleUpdaterTests.swift                   # Sparkle updater
-├── ConfettiViewTests.swift                     # Confetti view
-├── ClickOutsideModifierTests.swift             # Click-outside dismiss
-├── AppcastVersionParserTests.swift             # Appcast parsing
-├── NSScreenNotchTests.swift                    # Notch detection
-├── SmokeTests.swift                            # Sanity check
-└── MockAudioManager.swift                      # Audio manager mock
-```
+````
+Tests/OakTests/                        # 29 test files
+├── US001Tests.swift                   # Start focus session
+├── US002Tests.swift                   # Pomodoro presets (25/5, 50/10)
+├── US003Tests.swift                   # Pause and resume
+├── US004Tests.swift                   # Ambient audio playback
+├── US005Tests.swift                   # Session completion feedback
+├── US006Tests.swift                   # Progress tracking & persistence
+├── NotchCompanionViewTests.swift      # Main view tests
+├── NotchCompanionViewTests+Layout.swift
+├── NotchCompanionViewTests+SessionState.swift
+├── NotchWindowControllerTests.swift   # Window management
+├── NotchWindowControllerTests+NotchWindow.swift
+├── NotchWindowControllerTests+WindowBehavior.swift
+├── NotchWindowControllerTests+NotchFirstUI.swift
+├── AudioManagerTests.swift            # Audio engine
+├── AudioPersistenceTests.swift        # Audio settings persistence
+├── AccessibilityTests.swift           # Accessibility labels/hints
+├── AutoStartNextIntervalTests.swift   # Auto-start countdown
+├── LongBreakTests.swift               # Long break cycle
+├── ConfettiViewTests.swift            # Completion animation
+├── ClickOutsideModifierTests.swift    # Popover dismiss
+├── CountdownDisplayModeTests.swift    # Display format
+├── AlwaysOnTopTests.swift             # Window level
+├── NotificationTests.swift            # Notification permissions
+├── SessionCompletionNotificationTests.swift
+├── NSScreenNotchTests.swift           # Notch detection
+├── SparkleUpdaterTests.swift          # Update framework
+├── AppcastVersionParserTests.swift    # Appcast parsing
+├── SmokeTests.swift                   # Basic sanity
+└── MockAudioManager.swift             # Test double
 
-## Conventions
-
-### @MainActor on All Test Classes
-
-```swift
-@MainActor
-internal final class US003Tests: XCTestCase { ... }
-```
-
-### UserDefaults Isolation
-
-Every test uses a unique `UserDefaults` suite to prevent cross-test contamination:
-
-```swift
-override func setUp() async throws {
-    let suiteName = "OakTests.ClassName.\(UUID().uuidString)"
-    guard let userDefaults = UserDefaults(suiteName: suiteName) else {
-        XCTFail("Failed to create UserDefaults")
-        return
-    }
-    userDefaults.removePersistentDomain(forName: suiteName)
-    presetSuiteName = suiteName
-    // ... create dependencies with userDefaults
-}
-
-override func tearDown() async throws {
-    viewModel.cleanup()
-    UserDefaults(suiteName: presetSuiteName)?.removePersistentDomain(forName: presetSuiteName)
-}
-```
+## Mocking Strategy
 
 ### Protocol-Based Mocks
-
 ```swift
-// Mock notification service
-private final class MockNotificationService: SessionCompletionNotifying {
+class MockNotificationService: SessionCompletionNotifying {
     var didNotify = false
     func notifySessionComplete() { didNotify = true }
 }
+````
 
-// Mock audio manager
-@MainActor
-internal class MockAudioManager: AudioManager {
-    var playCalledWithTrack: AudioTrack?
-    var stopCallCount = 0
-    // ...
+### UserDefaults Isolation
+
+Each test creates isolated UserDefaults suites to prevent cross-test contamination:
+
+```swift
+let suiteName = "OakTests.ClassName.\(UUID().uuidString)"
+let userDefaults = UserDefaults(suiteName: suiteName)
+```
+
+### Cleanup in tearDown()
+
+```swift
+override func tearDown() {
+    viewModel.cleanup()
+    UserDefaults(suiteName: suiteName)?.removePersistentDomain(forName: suiteName)
+    super.tearDown()
 }
 ```
 
-### State Transition Testing
+## Test Coverage by Area
 
-Tests verify the complete FSM cycle:
-
-- `idle → running → paused → running → completed → (next) → running → ... → idle`
-- Individual transitions tested: `canStart`, `canPause`, `canResume`, `canStartNext`
-- Guard clauses tested: "cannot pause when not running", "cannot resume when not paused"
-
-### User Story Tests (US001–US006)
-
-Each `US00XTests` file corresponds to a user story from the PRD:
-
-- **US001**: Notch companion visibility and session start
-- **US002**: Preset selection (short 25/5, long 50/10)
-- **US003**: Pause and resume session with time preservation
-- **US004**: Built-in audio tracks, volume control
-- **US005**: Session completion, round counting
-- **US006**: Progress tracking, streaks, daily stats
-
-### Dependency Injection in Tests
-
-```swift
-viewModel = FocusSessionViewModel(
-    presetSettings: presetSettings,
-    audioManager: MockAudioManager(),
-    notificationService: MockNotificationService(),
-    completionSoundPlayer: MockSessionCompletionSoundPlayer()
-)
-```
-
-### TestClock Pattern
-
-For time-dependent tests (streaks, daily rollover), a `TestClock` is used:
-
-```swift
-private final class TestClock {
-    var currentDate: Date
-    func advance(days: Int) { ... }
-}
-```
+| Area              | Test Files                                            |
+| ----------------- | ----------------------------------------------------- |
+| Session lifecycle | US001, US002, US003, LongBreak, AutoStartNextInterval |
+| Audio             | US004, AudioManager, AudioPersistence                 |
+| Notifications     | US005, Notification, SessionCompletionNotification    |
+| Progress          | US006                                                 |
+| Notch UI          | NotchCompanionView, ConfettiView, NSScreenNotch       |
+| Window management | NotchWindowController (4 files)                       |
+| Settings          | CountdownDisplayMode, AlwaysOnTop                     |
+| Accessibility     | AccessibilityTests                                    |
+| Updates           | SparkleUpdater, AppcastVersionParser                  |
+| Misc              | Smoke, ClickOutsideModifier                           |
 
 ## Running Tests
 
 ```bash
-just test                            # All tests
-just test-verbose                    # Verbose output
-just test-class FocusSessionViewModelTests
-just test-method US003Tests testCanPauseActiveSession
+just test                          # Run all tests
+just test-class ClassName          # Run specific test class
+just test-method ClassName Method  # Run single test method
+just test-verbose                  # Run all tests with verbose output
 ```
-
-## CI Pipeline
-
-Tests run on every PR and push to `main` via `.github/workflows/ci.yml`:
-
-1. Lint: `swiftlint lint --strict`
-2. Build: `xcodebuild build CODE_SIGNING_ALLOWED=NO`
-3. Test: `xcodebuild test CODE_SIGNING_ALLOWED=NO`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Added
 
+- Keyboard shortcuts for timer control — Space to start/pause/resume, Escape to reset. Configurable in Settings with optional global hotkeys (#142)
+- Progress data export/import — Export session history as JSON or CSV, import from backup files. Data section in Settings with NSSavePanel/NSOpenPanel (#141)
 - Domain glossary (`CONTEXT.md`) — formal definitions for Session State, Preset, Round, Display Target, and other core terms
 - Codebase map documents in `.planning/codebase/` — STACK.md, ARCHITECTURE.md, STRUCTURE.md, CONVENTIONS.md, TESTING.md, INTEGRATIONS.md, CONCERNS.md
 - ADR-0003 — decision record for the glossary and codebase map approach
 - `.prettierrc` — markdown formatting defaults
+
+### Changed
+
+- Refactored internal architecture — extracted SessionStateMachine, SessionTimerService, WindowPositioning, PresetEditorView; split PresetSettingsStore into domain configs; merged NotchCompanionView extensions
 
 ## [0.5.30] - 2026-05-25
 

--- a/README.md
+++ b/README.md
@@ -49,8 +49,10 @@ In today's world of constant distractions, deep work has become increasingly rar
 - 🔄 **Smart breaks**: Automatic 15/20 min long breaks after 4 focus rounds
 - ▶️ **Session controls**: Start, pause, and resume your focus sessions
 - 🎵 **Ambient sounds**: Rain, forest, cafe, brown noise, and lo-fi to help you concentrate
+- ⌨️ **Keyboard shortcuts**: Press Space to start/pause/resume, Escape to reset — control sessions without touching the mouse
 - 📊 **Local tracking**: Track daily focus minutes, completed sessions, and 7-day streaks
 - 🕒 **Session timeline**: See each focus session and break from today with start/end times and durations
+- 💾 **Data export**: Export your progress as JSON or CSV, or import from a backup file
 - 🔄 **Auto-update**: Seamless updates via Sparkle framework
 
 ## Installation

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -91,6 +91,26 @@ Oak requires a MacBook with a notch (14" or 16" MacBook Pro from 2021 or later).
 2. Try restarting Oak
 3. Check that no other apps are using the notch area
 
+### Keyboard shortcuts not working
+
+Oak supports keyboard shortcuts (Space to start/pause, Escape to reset). If they're not responding:
+
+1. Check that shortcuts are enabled — open Settings (gear icon), scroll to **Keyboard**, and ensure "Enable keyboard shortcuts" is toggled on
+2. Make sure Oak is the active application — local shortcuts only work when Oak is in focus
+3. If you enabled "Global hotkeys" in Settings, you'll need to grant Accessibility permission:
+   - Open **System Settings** → **Privacy & Security** → **Accessibility**
+   - Add Oak to the list and enable the toggle
+   - Restart Oak after granting permission
+
+### Export/Import not working
+
+Oak lets you export your progress as JSON or CSV, or import from a backup:
+
+1. Export and import are available in Settings under the **Data** section
+2. If the buttons are disabled, ensure you're running Oak with at least one completed session
+3. Export opens a save dialog — choose a location you have write permission to
+4. Import only accepts `.json` files previously exported by Oak
+
 ### Settings not persisting
 
 Oak stores settings locally using UserDefaults. If settings aren't saving:


### PR DESCRIPTION
## What

Updates README.md, CHANGELOG.md, and TROUBLESHOOTING.md to document two recently-merged features:

- Keyboard shortcuts (Space to start/pause/resume, Escape to reset) — #142
- Progress data export/import (JSON/CSV) — #141

## Why

These features were implemented but not reflected in user-facing documentation. Users need to know:
- What keyboard shortcuts are available and how to enable them
- How to export/import their progress data for backup

## Changes

- **README.md**: Added keyboard shortcuts and data export to feature list
- **CHANGELOG.md**: Documented both features under Unreleased, plus summary of internal refactoring
- **TROUBLESHOOTING.md**: Added sections for keyboard shortcut issues and export/import troubleshooting