### PR TITLE
refactor(audio): extract audio engine boundary

### DIFF
--- a/Oak/Oak.xcodeproj/project.pbxproj
+++ b/Oak/Oak.xcodeproj/project.pbxproj
@@ -43,6 +43,7 @@
 		8C831319B8AF05D32A0F8608 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 08E0A4A56EADCDB21276DE81 /* Assets.xcassets */; };
 		8CA3EDDEB1C3C37D3CB1CF54 /* NotchCompanionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0679D26521D6F4E9C5774630 /* NotchCompanionView.swift */; };
 		8EACCC04A4D4A9A86608898A /* NotchCompanionViewTests+Layout.swift in Sources */ = {isa = PBXBuildFile; fileRef = A74529FF7AEFC6AB3D4B6935 /* NotchCompanionViewTests+Layout.swift */; };
+		900E3D31705B38756E037EA1 /* AudioEngineControlling.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E7C621CDFB0A0D1B1137478 /* AudioEngineControlling.swift */; };
 		91F4096D77B5684A1251EE01 /* SupportSectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9E56FB534D3736A6E1C03BD /* SupportSectionView.swift */; };
 		935A6BD932F4EC629908FE05 /* ambient_lofi.m4a in Resources */ = {isa = PBXBuildFile; fileRef = 63539C12247302E14148BE07 /* ambient_lofi.m4a */; };
 		98EA03D50041483DEFBB6984 /* SmokeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E00D04EC9E5E33BBF5D09F7 /* SmokeTests.swift */; };
@@ -146,6 +147,7 @@
 		841F3EFAB628759B783D66D3 /* AudioTrack.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioTrack.swift; sourceTree = "<group>"; };
 		85C93F37E0AC4AA71C304FDD /* US003Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = US003Tests.swift; sourceTree = "<group>"; };
 		85FAA8F73F21E099B201F0FB /* DisplayIDInitializationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DisplayIDInitializationTests.swift; sourceTree = "<group>"; };
+		8E7C621CDFB0A0D1B1137478 /* AudioEngineControlling.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioEngineControlling.swift; sourceTree = "<group>"; };
 		98D555E4182E199E8EC8D0B3 /* NotificationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationService.swift; sourceTree = "<group>"; };
 		A53A901D48495497B38B2A1E /* CountdownDisplayMode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CountdownDisplayMode.swift; sourceTree = "<group>"; };
 		A74529FF7AEFC6AB3D4B6935 /* NotchCompanionViewTests+Layout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NotchCompanionViewTests+Layout.swift"; sourceTree = "<group>"; };
@@ -322,6 +324,7 @@
 		A433A3CADD138B6EE89589F9 /* Services */ = {
 			isa = PBXGroup;
 			children = (
+				8E7C621CDFB0A0D1B1137478 /* AudioEngineControlling.swift */,
 				C348F7E99471145836A04408 /* AudioManager.swift */,
 				0F021683DF6D26584B0D714D /* BehaviorConfig.swift */,
 				C316C2930B2750A34E68538D /* DisplayConfig.swift */,
@@ -448,6 +451,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				900E3D31705B38756E037EA1 /* AudioEngineControlling.swift in Sources */,
 				D01FB63BF5CAA09DBAE33DD0 /* AudioManager.swift in Sources */,
 				B5C9AD5FC22FACC36FAA5620 /* AudioMenuView.swift in Sources */,
 				B51EEBF3FF0DC4E28F414828 /* AudioTrack.swift in Sources */,

--- a/Oak/Oak/Services/AudioEngineControlling.swift
+++ b/Oak/Oak/Services/AudioEngineControlling.swift
@@ -1,0 +1,64 @@
+import AVFoundation
+import Foundation
+
+// MARK: - AudioEngineControlling
+
+internal protocol AudioEngineControlling {
+    var isRunning: Bool { get }
+    var outputChannelCount: AVAudioChannelCount { get }
+    var outputSampleRate: Double { get }
+    func setMixerVolume(_ volume: Float)
+    func attachAndConnect(_ node: AVAudioNode)
+    func detach(_ node: AVAudioNode)
+    func prepare()
+    func start() throws
+    func stop()
+    func pause()
+}
+
+// MARK: - AudioEngineAdapter
+
+internal final class AudioEngineAdapter: AudioEngineControlling {
+    private let engine = AVAudioEngine()
+
+    internal var isRunning: Bool {
+        engine.isRunning
+    }
+
+    internal var outputChannelCount: AVAudioChannelCount {
+        engine.outputNode.outputFormat(forBus: 0).channelCount
+    }
+
+    internal var outputSampleRate: Double {
+        engine.outputNode.outputFormat(forBus: 0).sampleRate
+    }
+
+    internal func setMixerVolume(_ volume: Float) {
+        engine.mainMixerNode.outputVolume = volume
+    }
+
+    internal func attachAndConnect(_ node: AVAudioNode) {
+        engine.attach(node)
+        engine.connect(node, to: engine.mainMixerNode, format: nil)
+    }
+
+    internal func detach(_ node: AVAudioNode) {
+        engine.detach(node)
+    }
+
+    internal func prepare() {
+        engine.prepare()
+    }
+
+    internal func start() throws {
+        try engine.start()
+    }
+
+    internal func stop() {
+        engine.stop()
+    }
+
+    internal func pause() {
+        engine.pause()
+    }
+}

--- a/Oak/Oak/Services/AudioManager.swift
+++ b/Oak/Oak/Services/AudioManager.swift
@@ -3,68 +3,6 @@ import Combine
 import Foundation
 import os
 
-// MARK: - AudioEngineProtocol
-
-internal protocol AudioEngineProtocol {
-    var isRunning: Bool { get }
-    var outputChannelCount: AVAudioChannelCount { get }
-    var outputSampleRate: Double { get }
-    func setMixerVolume(_ volume: Float)
-    func attachAndConnect(_ node: AVAudioNode)
-    func detach(_ node: AVAudioNode)
-    func prepare()
-    func start() throws
-    func stop()
-    func pause()
-}
-
-// MARK: - AudioEngineAdapter
-
-internal final class AudioEngineAdapter: AudioEngineProtocol {
-    private let engine = AVAudioEngine()
-
-    var isRunning: Bool {
-        engine.isRunning
-    }
-
-    var outputChannelCount: AVAudioChannelCount {
-        engine.outputNode.outputFormat(forBus: 0).channelCount
-    }
-
-    var outputSampleRate: Double {
-        engine.outputNode.outputFormat(forBus: 0).sampleRate
-    }
-
-    func setMixerVolume(_ volume: Float) {
-        engine.mainMixerNode.outputVolume = volume
-    }
-
-    func attachAndConnect(_ node: AVAudioNode) {
-        engine.attach(node)
-        engine.connect(node, to: engine.mainMixerNode, format: nil)
-    }
-
-    func detach(_ node: AVAudioNode) {
-        engine.detach(node)
-    }
-
-    func prepare() {
-        engine.prepare()
-    }
-
-    func start() throws {
-        try engine.start()
-    }
-
-    func stop() {
-        engine.stop()
-    }
-
-    func pause() {
-        engine.pause()
-    }
-}
-
 // MARK: - AudioManager
 
 @MainActor
@@ -79,12 +17,12 @@ internal class AudioManager: ObservableObject {
     @Published var isPlaying: Bool = false
 
     private var audioPlayer: AVAudioPlayer?
-    private var audioEngine: (any AudioEngineProtocol)?
+    private var audioEngine: (any AudioEngineControlling)?
     private var audioNodes: [AVAudioNode] = []
     private let logger = Logger(subsystem: "com.productsway.oak.app", category: "AudioManager")
-    private let audioEngineFactory: () -> any AudioEngineProtocol
+    private let audioEngineFactory: () -> any AudioEngineControlling
 
-    init(audioEngineFactory: @escaping () -> any AudioEngineProtocol = { AudioEngineAdapter() }) {
+    init(audioEngineFactory: @escaping () -> any AudioEngineControlling = { AudioEngineAdapter() }) {
         self.audioEngineFactory = audioEngineFactory
     }
 

--- a/Oak/Tests/OakTests/AudioManagerTests.swift
+++ b/Oak/Tests/OakTests/AudioManagerTests.swift
@@ -4,7 +4,7 @@ import XCTest
 
 // MARK: - MockAudioEngine
 
-internal final class MockAudioEngine: AudioEngineProtocol {
+internal final class MockAudioEngine: AudioEngineControlling {
     var isRunning: Bool = false
     var outputChannelCount: AVAudioChannelCount = 2
     var outputSampleRate: Double = 44100

--- a/Oak/Tests/OakTests/MockAudioManager.swift
+++ b/Oak/Tests/OakTests/MockAudioManager.swift
@@ -31,7 +31,7 @@ internal final class MockAudioManager: AudioManager {
     }
 }
 
-private final class MockTestAudioEngine: AudioEngineProtocol {
+private final class MockTestAudioEngine: AudioEngineControlling {
     var isRunning: Bool = false
     var outputChannelCount: UInt32 = 2
     var outputSampleRate: Double = 44100


### PR DESCRIPTION
Move the audio engine abstraction into a dedicated capability-oriented service and update test doubles so AudioManager has a smaller, clearer core.\n\nGenerated with Codebuff 🤖\nCo-Authored-By: Codebuff <noreply@codebuff.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved the app’s audio engine architecture by centralizing audio engine control and management.
  * Preserved existing audio operations, including playback control, node management, mixer volume, and output configuration.
  * Updated audio-related test components to align with the revised engine interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->