### PR TITLE
fix(audio): keep ambient rendering real-time safe

### DIFF
--- a/Oak/Oak.xcodeproj/project.pbxproj
+++ b/Oak/Oak.xcodeproj/project.pbxproj
@@ -20,6 +20,7 @@
 		27D85C39AE3A893CB986535C /* NotchCompanionViewTests+SessionState.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCB9EFBE035ED14BBCAAD3D9 /* NotchCompanionViewTests+SessionState.swift */; };
 		29EFC7CC8DBCDE421107C0E6 /* NotchCompanionView+InsideNotch.swift in Sources */ = {isa = PBXBuildFile; fileRef = 047B20E550402C5D04E55B6E /* NotchCompanionView+InsideNotch.swift */; };
 		2ADA17F3F2B2E2ECB0DC32B7 /* FocusSessionViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53877747FE72F8926A70A9E0 /* FocusSessionViewModel.swift */; };
+		33CC64AC8D322C6C3A7F8191 /* AudioRenderBufferFiller.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1B5AE40E70CA467E91B27A0 /* AudioRenderBufferFiller.swift */; };
 		39B659A9DA438E70743E07F9 /* CircularProgressRing.swift in Sources */ = {isa = PBXBuildFile; fileRef = D875A8103C5D96B028D6ED5C /* CircularProgressRing.swift */; };
 		3BB10B768F1CD0C2E7F00EB5 /* AccessibilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E53FB903AF7AF6B4DE091AD /* AccessibilityTests.swift */; };
 		3ED5BDC623247CE16B62E99B /* ambient_rain.m4a in Resources */ = {isa = PBXBuildFile; fileRef = B92D2B2C025E4DB8856333A0 /* ambient_rain.m4a */; };
@@ -153,6 +154,7 @@
 		A74529FF7AEFC6AB3D4B6935 /* NotchCompanionViewTests+Layout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NotchCompanionViewTests+Layout.swift"; sourceTree = "<group>"; };
 		AAE52F59E069ECD05898D612 /* WindowPositioning.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowPositioning.swift; sourceTree = "<group>"; };
 		AC19349D6F25778FBE54A06F /* NSScreen+UUID.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSScreen+UUID.swift"; sourceTree = "<group>"; };
+		B1B5AE40E70CA467E91B27A0 /* AudioRenderBufferFiller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioRenderBufferFiller.swift; sourceTree = "<group>"; };
 		B1EB99EC9EF014772EA562EF /* README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
 		B678070C4468D7AD6171B2C2 /* SparkleUpdaterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SparkleUpdaterTests.swift; sourceTree = "<group>"; };
 		B74BB88C04B3824E97E3C561 /* US001Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = US001Tests.swift; sourceTree = "<group>"; };
@@ -326,6 +328,7 @@
 			children = (
 				8E7C621CDFB0A0D1B1137478 /* AudioEngineControlling.swift */,
 				C348F7E99471145836A04408 /* AudioManager.swift */,
+				B1B5AE40E70CA467E91B27A0 /* AudioRenderBufferFiller.swift */,
 				0F021683DF6D26584B0D714D /* BehaviorConfig.swift */,
 				C316C2930B2750A34E68538D /* DisplayConfig.swift */,
 				3B3AF8631A42998C419DD233 /* KeyboardShortcutService.swift */,
@@ -454,6 +457,7 @@
 				900E3D31705B38756E037EA1 /* AudioEngineControlling.swift in Sources */,
 				D01FB63BF5CAA09DBAE33DD0 /* AudioManager.swift in Sources */,
 				B5C9AD5FC22FACC36FAA5620 /* AudioMenuView.swift in Sources */,
+				33CC64AC8D322C6C3A7F8191 /* AudioRenderBufferFiller.swift in Sources */,
 				B51EEBF3FF0DC4E28F414828 /* AudioTrack.swift in Sources */,
 				DD2D9278720F6DDBE17D6D9C /* BehaviorConfig.swift in Sources */,
 				39B659A9DA438E70743E07F9 /* CircularProgressRing.swift in Sources */,

--- a/Oak/Oak/Services/AudioManager.swift
+++ b/Oak/Oak/Services/AudioManager.swift
@@ -186,71 +186,11 @@ internal class AudioManager: ObservableObject {
     }
 
     private func createSourceNode(for track: AudioTrack, generator: NoiseGenerator) -> AVAudioSourceNode? {
-        switch track {
-        case .none: nil
-        case .brownNoise: createBrownNoiseNode(generator: generator)
-        case .rain: createRainNode(generator: generator)
-        case .forest: createForestNode(generator: generator)
-        case .cafe: createCafeNode(generator: generator)
-        case .lofi: createLofiNode(generator: generator)
-        }
-    }
+        guard track != .none else { return nil }
 
-    private func createBrownNoiseNode(generator: NoiseGenerator) -> AVAudioSourceNode {
-        AVAudioSourceNode { _, _, _, outputBuffer in
-            Self.fillOutputBuffer(outputBuffer) {
-                generator.generateBrownNoise()
-            }
+        return AVAudioSourceNode { _, _, _, outputBuffer in
+            AudioRenderBufferFiller.fill(outputBuffer, generator: generator, track: track)
             return noErr
-        }
-    }
-
-    private func createRainNode(generator: NoiseGenerator) -> AVAudioSourceNode {
-        AVAudioSourceNode { _, _, _, outputBuffer in
-            Self.fillOutputBuffer(outputBuffer) {
-                generator.generateRainNoise()
-            }
-            return noErr
-        }
-    }
-
-    private func createForestNode(generator: NoiseGenerator) -> AVAudioSourceNode {
-        AVAudioSourceNode { _, _, _, outputBuffer in
-            Self.fillOutputBuffer(outputBuffer) {
-                generator.generateForestNoise()
-            }
-            return noErr
-        }
-    }
-
-    private func createCafeNode(generator: NoiseGenerator) -> AVAudioSourceNode {
-        AVAudioSourceNode { _, _, _, outputBuffer in
-            Self.fillOutputBuffer(outputBuffer) {
-                generator.generateCafeNoise()
-            }
-            return noErr
-        }
-    }
-
-    private func createLofiNode(generator: NoiseGenerator) -> AVAudioSourceNode {
-        AVAudioSourceNode { _, _, _, outputBuffer in
-            Self.fillOutputBuffer(outputBuffer) {
-                generator.generateLofiNoise()
-            }
-            return noErr
-        }
-    }
-
-    private static func fillOutputBuffer(_ outputBuffer: UnsafeMutablePointer<AudioBufferList>, sample: () -> Float) {
-        let bufferList = UnsafeMutableAudioBufferListPointer(outputBuffer)
-        for buffer in bufferList {
-            guard let mData = buffer.mData else { continue }
-            let frameCount = Int(buffer.mDataByteSize) / MemoryLayout<Float>.size
-            let samples = mData.assumingMemoryBound(to: Float.self)
-
-            for index in 0 ..< frameCount {
-                samples[index] = sample()
-            }
         }
     }
 

--- a/Oak/Oak/Services/AudioRenderBufferFiller.swift
+++ b/Oak/Oak/Services/AudioRenderBufferFiller.swift
@@ -1,0 +1,21 @@
+import AVFoundation
+import Foundation
+
+internal enum AudioRenderBufferFiller {
+    internal static func fill(
+        _ outputBuffer: UnsafeMutablePointer<AudioBufferList>,
+        generator: NoiseGenerator,
+        track: AudioTrack
+    ) {
+        let bufferList = UnsafeMutableAudioBufferListPointer(outputBuffer)
+        for buffer in bufferList {
+            guard let mData = buffer.mData else { continue }
+            let frameCount = Int(buffer.mDataByteSize) / MemoryLayout<Float>.size
+            let samples = mData.assumingMemoryBound(to: Float.self)
+
+            for index in 0 ..< frameCount {
+                samples[index] = generator.generate(track)
+            }
+        }
+    }
+}

--- a/Oak/Oak/Services/NoiseGenerator.swift
+++ b/Oak/Oak/Services/NoiseGenerator.swift
@@ -5,43 +5,79 @@ import Foundation
 /// render callbacks (audio thread), but each instance is owned exclusively by its render
 /// callback—there is no cross-thread sharing of state.
 internal final class NoiseGenerator: @unchecked Sendable {
+    private var randomState: UInt64
     private var brownNoiseLast: Float = 0
-    private var rainSeed: Float = 0
+    private var rainPhase: Float = 0
 
-    func generateBrownNoise() -> Float {
-        let white = Float.random(in: -1 ... 1)
+    internal init(seed: UInt64? = nil) {
+        if let seed {
+            randomState = seed == 0 ? 0xA5A5_5A5A_1234_5678 : seed
+        } else {
+            var generator = SystemRandomNumberGenerator()
+            let generatedSeed = generator.next()
+            randomState = generatedSeed == 0 ? 0xA5A5_5A5A_1234_5678 : generatedSeed
+        }
+    }
+
+    internal func generateBrownNoise() -> Float {
+        let white = nextFloat(in: -1 ... 1)
         brownNoiseLast = (brownNoiseLast + (0.02 * white)) / 1.02
         brownNoiseLast *= 3.5
         brownNoiseLast = max(-1, min(1, brownNoiseLast))
         return brownNoiseLast * 0.15
     }
 
-    func generateRainNoise() -> Float {
-        rainSeed += 0.01
-        let maxSeed = Float.pi * 2000
-        if rainSeed > maxSeed {
-            rainSeed -= maxSeed
+    internal func generateRainNoise() -> Float {
+        rainPhase += 0.01
+        let maxPhase = Float.pi * 2000
+        if rainPhase > maxPhase {
+            rainPhase -= maxPhase
         }
-        let noise = Float.random(in: -0.3 ... 0.3)
-        let modulation = sin(rainSeed * 2.0) * 0.5 + 0.5
+        let noise = nextFloat(in: -0.3 ... 0.3)
+        let modulation = sin(rainPhase * 2.0) * 0.5 + 0.5
         return noise * modulation
     }
 
-    func generateForestNoise() -> Float {
-        let noise = Float.random(in: -0.4 ... 0.4)
-        let modulation = sin(Float.random(in: 0 ... Float.pi * 2)) * 0.3
+    internal func generateForestNoise() -> Float {
+        let noise = nextFloat(in: -0.4 ... 0.4)
+        let modulation = sin(nextFloat(in: 0 ... Float.pi * 2)) * 0.3
         return (noise + modulation) * 0.5
     }
 
-    func generateCafeNoise() -> Float {
-        let base = Float.random(in: -0.2 ... 0.2)
-        let chatter = sin(Float.random(in: 0 ... Float.pi * 10)) * 0.15
+    internal func generateCafeNoise() -> Float {
+        let base = nextFloat(in: -0.2 ... 0.2)
+        let chatter = sin(nextFloat(in: 0 ... Float.pi * 10)) * 0.15
         return base + chatter
     }
 
-    func generateLofiNoise() -> Float {
-        let noise = Float.random(in: -0.25 ... 0.25)
-        let vinyl = Float.random(in: -0.05 ... 0.05)
+    internal func generateLofiNoise() -> Float {
+        let noise = nextFloat(in: -0.25 ... 0.25)
+        let vinyl = nextFloat(in: -0.05 ... 0.05)
         return noise + vinyl
+    }
+
+    internal func generate(_ track: AudioTrack) -> Float {
+        switch track {
+        case .brownNoise:
+            generateBrownNoise()
+        case .rain:
+            generateRainNoise()
+        case .forest:
+            generateForestNoise()
+        case .cafe:
+            generateCafeNoise()
+        case .lofi:
+            generateLofiNoise()
+        case .none:
+            0
+        }
+    }
+
+    private func nextFloat(in range: ClosedRange<Float>) -> Float {
+        randomState ^= randomState >> 12
+        randomState ^= randomState << 25
+        randomState ^= randomState >> 27
+        let unit = Float(randomState >> 40) / Float(0x00FF_FFFF)
+        return range.lowerBound + unit * (range.upperBound - range.lowerBound)
     }
 }

--- a/Oak/Tests/OakTests/AudioManagerTests.swift
+++ b/Oak/Tests/OakTests/AudioManagerTests.swift
@@ -108,6 +108,21 @@ internal final class NoiseGeneratorTests: XCTestCase {
         XCTAssertTrue(hasMagnitude, "Brown noise should produce non-zero values over time")
     }
 
+    func testSeededGeneratorsProduceTheSameSamples() {
+        let first = NoiseGenerator(seed: 42)
+        let second = NoiseGenerator(seed: 42)
+        let tracks: [AudioTrack] = [.brownNoise, .rain, .forest, .cafe, .lofi]
+
+        for track in tracks {
+            XCTAssertEqual(
+                first.generate(track),
+                second.generate(track),
+                accuracy: 0.000001,
+                "Seeded generators should produce deterministic samples for \(track.rawValue)"
+            )
+        }
+    }
+
     func testRainNoiseSeedWraps() {
         let generator = NoiseGenerator()
         // maxSeed = Float.pi * 2000 ≈ 6283; step = 0.01 per call → ~628,320 calls to wrap.


### PR DESCRIPTION
Use a lock-free seeded noise generator and move buffer filling out of the main-actor AudioManager render path. Add deterministic coverage for the generated samples.\n\nGenerated with Codebuff 🤖\nCo-Authored-By: Codebuff <noreply@codebuff.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>