### PR TITLE
fix(issue-104): improve timer accuracy and cache notch detection

### DIFF
--- a/Oak/Oak.xcodeproj/project.pbxproj
+++ b/Oak/Oak.xcodeproj/project.pbxproj
@@ -21,6 +21,7 @@
 		29EFC7CC8DBCDE421107C0E6 /* NotchCompanionView+InsideNotch.swift in Sources */ = {isa = PBXBuildFile; fileRef = 047B20E550402C5D04E55B6E /* NotchCompanionView+InsideNotch.swift */; };
 		2ADA17F3F2B2E2ECB0DC32B7 /* FocusSessionViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53877747FE72F8926A70A9E0 /* FocusSessionViewModel.swift */; };
 		33CC64AC8D322C6C3A7F8191 /* AudioRenderBufferFiller.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1B5AE40E70CA467E91B27A0 /* AudioRenderBufferFiller.swift */; };
+		3007E12D7C9341A05443402A /* SessionTimerServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA71DF374BE14AAE57917F4E /* SessionTimerServiceTests.swift */; };
 		39B659A9DA438E70743E07F9 /* CircularProgressRing.swift in Sources */ = {isa = PBXBuildFile; fileRef = D875A8103C5D96B028D6ED5C /* CircularProgressRing.swift */; };
 		3BB10B768F1CD0C2E7F00EB5 /* AccessibilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E53FB903AF7AF6B4DE091AD /* AccessibilityTests.swift */; };
 		3ED5BDC623247CE16B62E99B /* ambient_rain.m4a in Resources */ = {isa = PBXBuildFile; fileRef = B92D2B2C025E4DB8856333A0 /* ambient_rain.m4a */; };
@@ -168,6 +169,7 @@
 		D875A8103C5D96B028D6ED5C /* CircularProgressRing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CircularProgressRing.swift; sourceTree = "<group>"; };
 		D924AA0A4E1BF237979F3114 /* ProgressMenuView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProgressMenuView.swift; sourceTree = "<group>"; };
 		D9E56FB534D3736A6E1C03BD /* SupportSectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SupportSectionView.swift; sourceTree = "<group>"; };
+		DA71DF374BE14AAE57917F4E /* SessionTimerServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionTimerServiceTests.swift; sourceTree = "<group>"; };
 		DBFE863ED8125FD3D3029341 /* US004Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = US004Tests.swift; sourceTree = "<group>"; };
 		DCB9EFBE035ED14BBCAAD3D9 /* NotchCompanionViewTests+SessionState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NotchCompanionViewTests+SessionState.swift"; sourceTree = "<group>"; };
 		E43285E82910BB45D9CF9000 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
@@ -278,6 +280,7 @@
 				3912FED25041D62DE77347EA /* NotificationTests.swift */,
 				1049365D0D64C5E5471825BD /* NSScreenNotchTests.swift */,
 				131CDA9D17A7D22CBC67785C /* SessionCompletionNotificationTests.swift */,
+				DA71DF374BE14AAE57917F4E /* SessionTimerServiceTests.swift */,
 				0E00D04EC9E5E33BBF5D09F7 /* SmokeTests.swift */,
 				B678070C4468D7AD6171B2C2 /* SparkleUpdaterTests.swift */,
 				B74BB88C04B3824E97E3C561 /* US001Tests.swift */,
@@ -522,6 +525,7 @@
 				AC7D0BE9D2A43B9602F5FFA9 /* NotchWindowControllerTests.swift in Sources */,
 				25BAA3E90290CE446B9F7BFC /* NotificationTests.swift in Sources */,
 				F32ECEC3C32292DC1969C472 /* SessionCompletionNotificationTests.swift in Sources */,
+				3007E12D7C9341A05443402A /* SessionTimerServiceTests.swift in Sources */,
 				98EA03D50041483DEFBB6984 /* SmokeTests.swift in Sources */,
 				088CE53BA008F2E0ED7225E3 /* SparkleUpdaterTests.swift in Sources */,
 				1B420ABE27C55D4F4D474075 /* US001Tests.swift in Sources */,

--- a/Oak/Oak/Extensions/NSScreen+DisplayTarget.swift
+++ b/Oak/Oak/Extensions/NSScreen+DisplayTarget.swift
@@ -1,5 +1,6 @@
 import AppKit
 
+@MainActor
 internal extension NSScreen {
     static func displayID(for screen: NSScreen) -> CGDirectDisplayID? {
         guard let screenNumber = screen.deviceDescription[NSDeviceDescriptionKey("NSScreenNumber")] as? NSNumber else {

--- a/Oak/Oak/Extensions/NSScreen+UUID.swift
+++ b/Oak/Oak/Extensions/NSScreen+UUID.swift
@@ -27,8 +27,8 @@ internal extension NSScreen {
         NSScreenUUIDCache.shared.allScreens
     }
 
-    var hasNotch: Bool {
-        safeAreaInsets.top > 0
+    @MainActor var hasNotch: Bool {
+        NSScreenUUIDCache.shared.hasNotch(for: self)
     }
 }
 
@@ -37,6 +37,7 @@ internal final class NSScreenUUIDCache {
     internal static let shared = NSScreenUUIDCache()
 
     private var cache: [String: NSScreen] = [:]
+    private var notchCache: [String: Bool] = [:]
     private var observer: Any?
 
     private init() {
@@ -56,24 +57,44 @@ internal final class NSScreenUUIDCache {
             object: nil,
             queue: .main
         ) { [weak self] _ in
-            Task { @MainActor in self?.rebuildCache() }
+            // The observer is registered on the main queue, so rebuilding is MainActor-isolated.
+            MainActor.assumeIsolated {
+                self?.rebuildCache()
+            }
         }
     }
 
     private func rebuildCache() {
         var newCache: [String: NSScreen] = [:]
+        var newNotchCache: [String: Bool] = [:]
 
         for screen in NSScreen.screens {
             if let uuid = screen.displayUUID {
                 newCache[uuid] = screen
+                newNotchCache[uuid] = screen.safeAreaInsets.top > 0
             }
         }
 
         cache = newCache
+        notchCache = newNotchCache
     }
 
     func screen(forUUID uuid: String) -> NSScreen? {
         cache[uuid]
+    }
+
+    func hasNotch(for screen: NSScreen) -> Bool {
+        guard let uuid = screen.displayUUID else {
+            return screen.safeAreaInsets.top > 0
+        }
+
+        if let cachedValue = notchCache[uuid] {
+            return cachedValue
+        }
+
+        let value = screen.safeAreaInsets.top > 0
+        notchCache[uuid] = value
+        return value
     }
 
     var allScreens: [String: NSScreen] {

--- a/Oak/Oak/Services/SessionTimerService.swift
+++ b/Oak/Oak/Services/SessionTimerService.swift
@@ -15,6 +15,9 @@ internal final class SessionTimerService: ObservableObject {
     private var timer: Timer?
     private var autoStartTimer: Timer?
     private var sessionEndDate: Date?
+    private var remainingInterval: TimeInterval = 0
+    private var autoStartEndDate: Date?
+    private static let timerInterval: TimeInterval = 0.25
 
     deinit {
         timer?.invalidate()
@@ -23,30 +26,36 @@ internal final class SessionTimerService: ObservableObject {
 
     func start(seconds: Int) {
         timer?.invalidate()
+        autoStartTimer?.invalidate()
+        autoStartTimer = nil
+        autoStartEndDate = nil
+        autoStartCountdown = 0
         sessionDuration = seconds
         remainingSeconds = seconds
-        sessionEndDate = Date().addingTimeInterval(TimeInterval(seconds))
-        timer = Timer.scheduledTimer(withTimeInterval: 1.0, repeats: true) { [weak self] _ in
-            Task { @MainActor in
-                self?.tick()
-            }
+        remainingInterval = TimeInterval(seconds)
+        sessionEndDate = Date().addingTimeInterval(remainingInterval)
+        timer = makeRepeatingTimer { [weak self] in
+            self?.tick()
         }
+        tick()
     }
 
     func pause() {
         timer?.invalidate()
         timer = nil
+        if let sessionEndDate {
+            remainingInterval = max(0, sessionEndDate.timeIntervalSinceNow)
+        }
         sessionEndDate = nil
     }
 
     func resume() {
         guard timer == nil else { return }
-        sessionEndDate = Date().addingTimeInterval(TimeInterval(remainingSeconds))
-        timer = Timer.scheduledTimer(withTimeInterval: 1.0, repeats: true) { [weak self] _ in
-            Task { @MainActor in
-                self?.tick()
-            }
+        sessionEndDate = Date().addingTimeInterval(remainingInterval)
+        timer = makeRepeatingTimer { [weak self] in
+            self?.tick()
         }
+        tick()
     }
 
     func stop() {
@@ -58,25 +67,39 @@ internal final class SessionTimerService: ObservableObject {
         autoStartCountdown = 0
         sessionDuration = 0
         sessionEndDate = nil
+        remainingInterval = 0
+        autoStartEndDate = nil
     }
 
     func startAutoStartCountdown() {
-        autoStartCountdown = 10
         autoStartTimer?.invalidate()
-        autoStartTimer = Timer.scheduledTimer(withTimeInterval: 1.0, repeats: true) { [weak self] _ in
-            Task { @MainActor in
-                self?.tickAutoStart()
-            }
+        autoStartCountdown = 10
+        autoStartEndDate = Date().addingTimeInterval(TimeInterval(autoStartCountdown))
+        autoStartTimer = makeRepeatingTimer { [weak self] in
+            self?.tickAutoStart()
         }
+        tickAutoStart()
     }
 
     func cancelAutoStartCountdown() {
         autoStartTimer?.invalidate()
         autoStartTimer = nil
+        autoStartEndDate = nil
         autoStartCountdown = 0
     }
 
     // MARK: - Private
+
+    private func makeRepeatingTimer(action: @escaping @MainActor () -> Void) -> Timer {
+        // Timer callbacks run on MainActor because every timer is installed on RunLoop.main.
+        let timer = Timer(timeInterval: Self.timerInterval, repeats: true) { _ in
+            MainActor.assumeIsolated {
+                action()
+            }
+        }
+        RunLoop.main.add(timer, forMode: .common)
+        return timer
+    }
 
     private func tick() {
         guard let sessionEndDate else {
@@ -86,22 +109,32 @@ internal final class SessionTimerService: ObservableObject {
             return
         }
 
-        remainingSeconds = max(0, Int(ceil(sessionEndDate.timeIntervalSinceNow)))
+        remainingInterval = max(0, sessionEndDate.timeIntervalSinceNow)
+        remainingSeconds = max(0, Int(ceil(remainingInterval)))
 
         if remainingSeconds <= 0 {
             timer?.invalidate()
             timer = nil
             self.sessionEndDate = nil
+            remainingInterval = 0
             timerFinished.send()
         }
     }
 
     private func tickAutoStart() {
-        autoStartCountdown -= 1
-        if autoStartCountdown <= 0 {
+        guard let autoStartEndDate else {
             autoStartTimer?.invalidate()
             autoStartTimer = nil
-            autoStartCountdown = 0
+            return
+        }
+
+        let remainingInterval = max(0, autoStartEndDate.timeIntervalSinceNow)
+        autoStartCountdown = max(0, Int(ceil(remainingInterval)))
+
+        if autoStartCountdown == 0 {
+            autoStartTimer?.invalidate()
+            autoStartTimer = nil
+            self.autoStartEndDate = nil
             autoStartFinished.send()
         }
     }

--- a/Oak/Tests/OakTests/AutoStartNextIntervalTests.swift
+++ b/Oak/Tests/OakTests/AutoStartNextIntervalTests.swift
@@ -258,12 +258,10 @@ internal final class AutoStartNextIntervalTests: XCTestCase {
         var receivedValue: Int?
 
         let cancellable = viewModel.$autoStartCountdown
-            .dropFirst() // Skip initial value
+            .first { $0 > 0 }
             .sink { value in
-                if value > 0 {
-                    receivedValue = value
-                    expectation.fulfill()
-                }
+                receivedValue = value
+                expectation.fulfill()
             }
 
         viewModel.startSession()

--- a/Oak/Tests/OakTests/NSScreenNotchTests.swift
+++ b/Oak/Tests/OakTests/NSScreenNotchTests.swift
@@ -107,6 +107,25 @@ internal final class NSScreenNotchTests: XCTestCase {
         }
     }
 
+    func testHasNotchCacheRefreshesAfterScreenChange() throws {
+        guard let mainScreen = NSScreen.main else {
+            throw XCTSkip("No main screen available for testing")
+        }
+
+        _ = mainScreen.hasNotch
+        NotificationCenter.default.post(
+            name: NSApplication.didChangeScreenParametersNotification,
+            object: nil
+        )
+        RunLoop.main.run(until: Date().addingTimeInterval(0.1))
+
+        XCTAssertEqual(
+            mainScreen.hasNotch,
+            mainScreen.safeAreaInsets.top > 0,
+            "Cached notch status should be refreshed after screen parameters change"
+        )
+    }
+
     func testNotchedScreenDetection() {
         // Find screen with actual notch
         let notchedScreen = NSScreen.screens.first { $0.hasNotch }

--- a/Oak/Tests/OakTests/SessionTimerServiceTests.swift
+++ b/Oak/Tests/OakTests/SessionTimerServiceTests.swift
@@ -1,0 +1,49 @@
+import Foundation
+import XCTest
+@testable import Oak
+
+@MainActor
+internal final class SessionTimerServiceTests: XCTestCase {
+    func testSessionTimerFiresInCommonRunLoopModes() {
+        let service = SessionTimerService()
+        service.start(seconds: 2)
+
+        let deadline = Date().addingTimeInterval(1.2)
+        while Date() < deadline {
+            _ = RunLoop.main.run(mode: .eventTracking, before: deadline)
+        }
+
+        XCTAssertLessThan(service.remainingSeconds, 2, "Session timer should tick in common run-loop modes")
+        service.stop()
+    }
+
+    func testAutoStartCountdownUsesElapsedTime() {
+        let service = SessionTimerService()
+        service.startAutoStartCountdown()
+
+        RunLoop.main.run(until: Date().addingTimeInterval(1.2))
+
+        XCTAssertLessThanOrEqual(service.autoStartCountdown, 9)
+        XCTAssertGreaterThan(service.autoStartCountdown, 0)
+        service.cancelAutoStartCountdown()
+    }
+
+    func testPauseAndResumePreserveSubsecondRemainingInterval() {
+        let service = SessionTimerService()
+        service.start(seconds: 3)
+        RunLoop.main.run(until: Date().addingTimeInterval(1.8))
+        service.pause()
+
+        var didFinish = false
+        let cancellable = service.timerFinished.sink {
+            didFinish = true
+        }
+
+        service.resume()
+        RunLoop.main.run(until: Date().addingTimeInterval(1.5))
+
+        XCTAssertTrue(didFinish, "The timer should finish after the preserved fractional remainder elapses")
+        cancellable.cancel()
+        service.stop()
+    }
+}


### PR DESCRIPTION
Improve issue #104 session timing and notch detection reliability.\n\n- Track timer deadlines with fractional elapsed time so pause/resume preserves sub-second remainder.\n- Run timer callbacks in common run-loop modes and cancel stale auto-start state when starting a session.\n- Cache notch detection by display UUID and refresh it when screen parameters change.\n- Add regression coverage for timer precision, run-loop modes, auto-start elapsed time, and notch-cache refresh.\n\nValidation: 304 tests passed, 1 skipped; SwiftLint and SwiftFormat passed.