### PR TITLE
feat(audio): add personal sound library

### DIFF
--- a/.github/workflows/macos-test-build.yml
+++ b/.github/workflows/macos-test-build.yml
@@ -72,7 +72,7 @@ jobs:
           test -d "$app_path"
           codesign --force --deep --sign - "$app_path"
           codesign --verify --deep --strict --verbose=2 "$app_path"
-          lipo -verify_arch arm64 "$app_path/Contents/MacOS/Oak"
+          lipo "$app_path/Contents/MacOS/Oak" -verify_arch arm64
 
       - name: Package app
         run: |

--- a/.github/workflows/macos-test-build.yml
+++ b/.github/workflows/macos-test-build.yml
@@ -1,0 +1,111 @@
+name: macOS Test Build
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+concurrency:
+  group: macos-test-build-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build test app
+    runs-on: macos-26
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Select Xcode 16
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: latest-stable
+
+      - name: Resolve build metadata
+        id: metadata
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          if [[ -n "$PR_NUMBER" ]]; then
+            build_label="pr-${PR_NUMBER}"
+          else
+            build_label="manual-${GITHUB_RUN_NUMBER}"
+          fi
+
+          latest_tag="$(git describe --tags --match 'v*' --abbrev=0 2>/dev/null || true)"
+          marketing_version="${latest_tag#v}"
+          if [[ -z "$marketing_version" ]]; then
+            marketing_version="0.0.0"
+          fi
+
+          short_sha="${GITHUB_SHA::7}"
+          echo "artifact_name=oak-macos-test-${build_label}-${short_sha}" >> "$GITHUB_OUTPUT"
+          echo "archive_name=Oak-${build_label}-${short_sha}.zip" >> "$GITHUB_OUTPUT"
+          echo "marketing_version=$marketing_version" >> "$GITHUB_OUTPUT"
+
+      - name: Build Release app
+        run: |
+          xcodebuild \
+            -project Oak/Oak.xcodeproj \
+            -scheme Oak \
+            -configuration Release \
+            -destination 'generic/platform=macOS' \
+            -derivedDataPath /tmp/oak-test-build \
+            build \
+            ARCHS=arm64 \
+            ONLY_ACTIVE_ARCH=NO \
+            MARKETING_VERSION="${{ steps.metadata.outputs.marketing_version }}" \
+            CURRENT_PROJECT_VERSION="${GITHUB_RUN_NUMBER}" \
+            CODE_SIGNING_ALLOWED=NO \
+            CODE_SIGNING_REQUIRED=NO \
+            CODE_SIGN_IDENTITY=""
+
+      - name: Ad-hoc sign and verify app
+        run: |
+          app_path="/tmp/oak-test-build/Build/Products/Release/Oak.app"
+          test -d "$app_path"
+          codesign --force --deep --sign - "$app_path"
+          codesign --verify --deep --strict --verbose=2 "$app_path"
+          lipo -verify_arch arm64 "$app_path/Contents/MacOS/Oak"
+
+      - name: Package app
+        run: |
+          ditto \
+            -c \
+            -k \
+            --sequesterRsrc \
+            --keepParent \
+            /tmp/oak-test-build/Build/Products/Release/Oak.app \
+            "/tmp/${{ steps.metadata.outputs.archive_name }}"
+
+      - name: Upload test app
+        uses: actions/upload-artifact@v7
+        with:
+          name: ${{ steps.metadata.outputs.artifact_name }}
+          path: /tmp/${{ steps.metadata.outputs.archive_name }}
+          if-no-files-found: error
+          compression-level: 0
+          retention-days: 7
+
+      - name: Add verification instructions
+        env:
+          ARCHIVE_NAME: ${{ steps.metadata.outputs.archive_name }}
+          ARTIFACT_NAME: ${{ steps.metadata.outputs.artifact_name }}
+        run: |
+          cat >> "$GITHUB_STEP_SUMMARY" <<EOF
+          ## Test Oak
+
+          1. Download the **${ARTIFACT_NAME}** artifact from this run.
+          2. Unzip the downloaded artifact, then unzip **${ARCHIVE_NAME}**.
+          3. Move **Oak.app** to **Applications**.
+          4. Control-click **Oak.app**, select **Open**, and confirm the first launch.
+          5. Open Oak's sound library. Import, select, play, and remove a personal sound. Confirm that built-in sounds still play.
+
+          This build has an ad-hoc signature, but it is not notarized. Gatekeeper can require **System Settings → Privacy & Security → Open Anyway**.
+          EOF

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -64,9 +64,10 @@ Background sound played during focus sessions:
 
 | Term | Definition |
 | --- | --- |
-| **Track** | A named ambient sound (Rain, Forest, Cafe, Brown Noise, Lo-Fi, or None). |
+| **Track** | A named ambient sound selected for playback. |
 | **Built-in Track** | A bundled `.m4a` audio file shipped with the app. |
 | **Generated Track** | A sound generated algorithmically at runtime when no bundled file is available. |
+| **Personal Sound** | An audio file imported by the user and copied into Oak's local sound library. |
 
 ## Display Target
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -62,6 +62,19 @@ just open
 just check-sounds
 ```
 
+## Test a Pull Request Build
+
+The `macOS Test Build` workflow runs for pull requests and manual workflow dispatches. It uploads an Apple Silicon
+Release build as an artifact for 7 days. Open the workflow run, download the `oak-macos-test-*` artifact, and unzip
+both the downloaded artifact and its `Oak-*.zip` file. Move `Oak.app` to Applications before testing it.
+
+The app has an ad-hoc signature but is not notarized. On first launch, Control-click `Oak.app`, select **Open**, and
+confirm the prompt. If macOS still blocks the app, use **System Settings → Privacy & Security → Open Anyway**.
+
+For personal sound verification, open Oak's sound library and import a supported audio file. Select and play the
+personal sound, restart Oak to confirm that it remains available, remove it, and confirm that built-in sounds still
+play.
+
 ## Code Quality Commands
 
 ```bash

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -91,7 +91,12 @@ Oak expects bundled ambient files under `Oak/Oak/Resources/Sounds` with these ba
 - `ambient_brown_noise`
 - `ambient_lofi`
 
-Supported extensions: `.m4a` (preferred), `.wav`, `.mp3`.
+Bundled tracks use `.m4a` (preferred), `.wav`, or `.mp3` files.
+
+Users can also import `.m4a`, `.wav`, `.mp3`, `.aac`, `.aiff`, `.aif`, and `.caf` files from the sound library
+in Oak's notch popover. Oak validates each file and copies it to `~/Library/Application Support/Oak/Sounds`, so
+playback remains available if the original file moves or is removed. The copied files are user-managed data and
+must not be added to the app bundle.
 
 ### 🎵 Sound Attribution
 

--- a/Oak/Oak.xcodeproj/project.pbxproj
+++ b/Oak/Oak.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		11949A6E7635E4BC247D1A97 /* TransientPopover.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9239254E9493D78E223CE6D /* TransientPopover.swift */; };
 		16AB818C370C3132420E8C87 /* ProgressData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1CDDE42AD58F6B067B64ED90 /* ProgressData.swift */; };
 		1941B67DA3C25D4A42BB7D6D /* PresetSettingsStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1387A36E301B5A6EA9BB4A85 /* PresetSettingsStore.swift */; };
+		1A5C874911D14D6E9436E2AB /* AudioSelection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B4036DF213344159CE1710B /* AudioSelection.swift */; };
 		1B420ABE27C55D4F4D474075 /* US001Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B74BB88C04B3824E97E3C561 /* US001Tests.swift */; };
 		1B89D6E392D0EBFBE60F788E /* UpdateSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 630A26F2F361CCE214543440 /* UpdateSettingsView.swift */; };
 		1D12A36EE6767DD4A7CF73C9 /* NotchWindowControllerTests+NotchFirstUI.swift in Sources */ = {isa = PBXBuildFile; fileRef = E680D8D9839B944EB6CB5723 /* NotchWindowControllerTests+NotchFirstUI.swift */; };
@@ -31,6 +32,7 @@
 		4B5B7AD41E542963653F229A /* NotchWindowControllerTests+WindowBehavior.swift in Sources */ = {isa = PBXBuildFile; fileRef = 814659335F8FBC1EB95296FD /* NotchWindowControllerTests+WindowBehavior.swift */; };
 		4D92A0354DDAC317E9E44D17 /* LongBreakTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83E7ADCEF210103CF3189D41 /* LongBreakTests.swift */; };
 		4D9BF99164E9F1A8F0F802DE /* WindowPositioning.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAE52F59E069ECD05898D612 /* WindowPositioning.swift */; };
+		4F893BF0E39843998685B4C1 /* CustomAudioLibrary.swift in Sources */ = {isa = PBXBuildFile; fileRef = A823E58A8669488AB1D4F63C /* CustomAudioLibrary.swift */; };
 		4EBBE83E80DF3FF02EBDAE16 /* SessionDurationConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 454BAD66455AFEFEFD7EEA79 /* SessionDurationConfig.swift */; };
 		542154C3442D3F88977C493D /* ClickOutsideModifierTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E813C6E3CE44E2E0F36F640 /* ClickOutsideModifierTests.swift */; };
 		549C9C52E05194F19EB02E4C /* SessionCycleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 015DAE9095C32458E31C602E /* SessionCycleTests.swift */; };
@@ -74,6 +76,7 @@
 		C1C2CDACE52EEF5146C83881 /* ProgressMenuView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D924AA0A4E1BF237979F3114 /* ProgressMenuView.swift */; };
 		CB2C7AF21FF6FDEB1F6D84FF /* ProgressStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7C2456BF177F3FF003681C9 /* ProgressStoreTests.swift */; };
 		CB30D8321F8BFB7C2708E906 /* DisplayConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = C316C2930B2750A34E68538D /* DisplayConfig.swift */; };
+		CC90D51435874DF4894D7611 /* CustomAudioLibraryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E16C9B4A5B2F44EAA1A0C302 /* CustomAudioLibraryTests.swift */; };
 		CE3A4934C57D1C203D016F96 /* SessionModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23F2FC6738FCAE0999D42A11 /* SessionModels.swift */; };
 		D01FB63BF5CAA09DBAE33DD0 /* AudioManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C348F7E99471145836A04408 /* AudioManager.swift */; };
 		D9BC1320EE869D9AD7FE40AE /* SparkleUpdater.swift in Sources */ = {isa = PBXBuildFile; fileRef = 770CCC886CF6A5E903159704 /* SparkleUpdater.swift */; };
@@ -164,9 +167,11 @@
 		85FAA8F73F21E099B201F0FB /* DisplayIDInitializationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DisplayIDInitializationTests.swift; sourceTree = "<group>"; };
 		8E7C621CDFB0A0D1B1137478 /* AudioEngineControlling.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioEngineControlling.swift; sourceTree = "<group>"; };
 		985C59F06B49B761EA5A1324 /* SessionCycle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionCycle.swift; sourceTree = "<group>"; };
+		9B4036DF213344159CE1710B /* AudioSelection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioSelection.swift; sourceTree = "<group>"; };
 		98D555E4182E199E8EC8D0B3 /* NotificationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationService.swift; sourceTree = "<group>"; };
 		A53A901D48495497B38B2A1E /* CountdownDisplayMode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CountdownDisplayMode.swift; sourceTree = "<group>"; };
 		A74529FF7AEFC6AB3D4B6935 /* NotchCompanionViewTests+Layout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NotchCompanionViewTests+Layout.swift"; sourceTree = "<group>"; };
+		A823E58A8669488AB1D4F63C /* CustomAudioLibrary.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomAudioLibrary.swift; sourceTree = "<group>"; };
 		AAE52F59E069ECD05898D612 /* WindowPositioning.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowPositioning.swift; sourceTree = "<group>"; };
 		AC19349D6F25778FBE54A06F /* NSScreen+UUID.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSScreen+UUID.swift"; sourceTree = "<group>"; };
 		B1B5AE40E70CA467E91B27A0 /* AudioRenderBufferFiller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioRenderBufferFiller.swift; sourceTree = "<group>"; };
@@ -187,6 +192,7 @@
 		DBFE863ED8125FD3D3029341 /* US004Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = US004Tests.swift; sourceTree = "<group>"; };
 		DCB9EFBE035ED14BBCAAD3D9 /* NotchCompanionViewTests+SessionState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NotchCompanionViewTests+SessionState.swift"; sourceTree = "<group>"; };
 		E30A3753B98185442B548C87 /* AmbientAudioPlaybackTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AmbientAudioPlaybackTests.swift; sourceTree = "<group>"; };
+		E16C9B4A5B2F44EAA1A0C302 /* CustomAudioLibraryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomAudioLibraryTests.swift; sourceTree = "<group>"; };
 		E43285E82910BB45D9CF9000 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		E680D8D9839B944EB6CB5723 /* NotchWindowControllerTests+NotchFirstUI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NotchWindowControllerTests+NotchFirstUI.swift"; sourceTree = "<group>"; };
 		E7C2456BF177F3FF003681C9 /* ProgressStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProgressStoreTests.swift; sourceTree = "<group>"; };
@@ -211,6 +217,7 @@
 		01D9F58885F69FCDA63E90F6 /* Models */ = {
 			isa = PBXGroup;
 			children = (
+				9B4036DF213344159CE1710B /* AudioSelection.swift */,
 				841F3EFAB628759B783D66D3 /* AudioTrack.swift */,
 				A53A901D48495497B38B2A1E /* CountdownDisplayMode.swift */,
 				164FAFB05B901C05BD1479BF /* NotchLayout.swift */,
@@ -284,6 +291,7 @@
 				3CC50430910EB73FAE1074FE /* AutoStartNextIntervalTests.swift */,
 				0E813C6E3CE44E2E0F36F640 /* ClickOutsideModifierTests.swift */,
 				14E1129CEDF63355578B0485 /* ConfettiViewTests.swift */,
+				E16C9B4A5B2F44EAA1A0C302 /* CustomAudioLibraryTests.swift */,
 				F294622BEE001AE06968C35C /* CountdownDisplayModeTests.swift */,
 				85FAA8F73F21E099B201F0FB /* DisplayIDInitializationTests.swift */,
 				83E7ADCEF210103CF3189D41 /* LongBreakTests.swift */,
@@ -356,6 +364,7 @@
 				C348F7E99471145836A04408 /* AudioManager.swift */,
 				B1B5AE40E70CA467E91B27A0 /* AudioRenderBufferFiller.swift */,
 				0F021683DF6D26584B0D714D /* BehaviorConfig.swift */,
+				A823E58A8669488AB1D4F63C /* CustomAudioLibrary.swift */,
 				C316C2930B2750A34E68538D /* DisplayConfig.swift */,
 				3B3AF8631A42998C419DD233 /* KeyboardShortcutService.swift */,
 				5DF023F144789D230C0B954F /* NoiseGenerator.swift */,
@@ -486,10 +495,12 @@
 				D01FB63BF5CAA09DBAE33DD0 /* AudioManager.swift in Sources */,
 				B5C9AD5FC22FACC36FAA5620 /* AudioMenuView.swift in Sources */,
 				33CC64AC8D322C6C3A7F8191 /* AudioRenderBufferFiller.swift in Sources */,
+				1A5C874911D14D6E9436E2AB /* AudioSelection.swift in Sources */,
 				B51EEBF3FF0DC4E28F414828 /* AudioTrack.swift in Sources */,
 				DD2D9278720F6DDBE17D6D9C /* BehaviorConfig.swift in Sources */,
 				39B659A9DA438E70743E07F9 /* CircularProgressRing.swift in Sources */,
 				ADE41CB716798207A29851E9 /* ConfettiView.swift in Sources */,
+				4F893BF0E39843998685B4C1 /* CustomAudioLibrary.swift in Sources */,
 				82C6E45CC0A2D94BBBB83623 /* CountdownDisplayMode.swift in Sources */,
 				CB30D8321F8BFB7C2708E906 /* DisplayConfig.swift in Sources */,
 				2ADA17F3F2B2E2ECB0DC32B7 /* FocusSessionViewModel.swift in Sources */,
@@ -540,6 +551,7 @@
 				81C83510720895955C3CAF42 /* AutoStartNextIntervalTests.swift in Sources */,
 				542154C3442D3F88977C493D /* ClickOutsideModifierTests.swift in Sources */,
 				EC877E270C24B19E01A1DDE4 /* ConfettiViewTests.swift in Sources */,
+				CC90D51435874DF4894D7611 /* CustomAudioLibraryTests.swift in Sources */,
 				EBE81F10378684B523C9D931 /* CountdownDisplayModeTests.swift in Sources */,
 				DF2B1968E6C57A06679E46B4 /* DisplayIDInitializationTests.swift in Sources */,
 				4D92A0354DDAC317E9E44D17 /* LongBreakTests.swift in Sources */,

--- a/Oak/Oak/Models/AudioSelection.swift
+++ b/Oak/Oak/Models/AudioSelection.swift
@@ -3,8 +3,12 @@ import Foundation
 internal struct CustomAudioAsset: Equatable, Hashable, Identifiable {
     internal let url: URL
 
+    internal init(url: URL) {
+        self.url = url.resolvingSymlinksInPath().standardizedFileURL
+    }
+
     internal var id: String {
-        url.standardizedFileURL.path
+        url.path
     }
 
     internal var name: String {

--- a/Oak/Oak/Models/AudioSelection.swift
+++ b/Oak/Oak/Models/AudioSelection.swift
@@ -1,0 +1,49 @@
+import Foundation
+
+internal struct CustomAudioAsset: Equatable, Hashable, Identifiable {
+    internal let url: URL
+
+    internal var id: String {
+        url.standardizedFileURL.path
+    }
+
+    internal var name: String {
+        url.deletingPathExtension().lastPathComponent
+    }
+}
+
+internal enum AudioSelection: Equatable, Identifiable {
+    case builtIn(AudioTrack)
+    case custom(CustomAudioAsset)
+
+    internal var id: String {
+        switch self {
+        case let .builtIn(track):
+            "built-in-\(track.id)"
+        case let .custom(asset):
+            "custom-\(asset.id)"
+        }
+    }
+
+    internal var name: String {
+        switch self {
+        case let .builtIn(track):
+            track.rawValue
+        case let .custom(asset):
+            asset.name
+        }
+    }
+
+    internal var systemImageName: String {
+        switch self {
+        case let .builtIn(track):
+            track.systemImageName
+        case .custom:
+            "music.note"
+        }
+    }
+
+    internal var isNone: Bool {
+        self == .builtIn(.none)
+    }
+}

--- a/Oak/Oak/Models/AudioSelection.swift
+++ b/Oak/Oak/Models/AudioSelection.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-internal struct CustomAudioAsset: Equatable, Hashable, Identifiable {
+internal struct CustomAudioAsset: Equatable, Hashable, Identifiable, Sendable {
     internal let url: URL
 
     internal init(url: URL) {

--- a/Oak/Oak/Models/AudioTrack.swift
+++ b/Oak/Oak/Models/AudioTrack.swift
@@ -41,5 +41,5 @@ internal enum AudioTrack: String, CaseIterable, Identifiable {
         }
     }
 
-    static let supportedAudioExtensions = ["m4a", "wav", "mp3"]
+    static let supportedAudioExtensions = ["m4a", "wav", "mp3", "aac", "aiff", "aif", "caf"]
 }

--- a/Oak/Oak/Services/AudioManager.swift
+++ b/Oak/Oak/Services/AudioManager.swift
@@ -34,7 +34,9 @@ internal class AudioManager: ObservableObject {
     ) {
         ambientPlayback = AmbientAudioPlayback(audioEngineFactory: audioEngineFactory)
         self.customAudioLibrary = customAudioLibrary
-        reloadCustomAssets()
+        Task { [weak self] in
+            await self?.reloadCustomAssets()
+        }
     }
 
     func play(track: AudioTrack) {
@@ -115,7 +117,7 @@ internal class AudioManager: ObservableObject {
     }
 
     @discardableResult
-    func importCustomAudio(from sourceURL: URL) -> CustomAudioAsset? {
+    func importCustomAudio(from sourceURL: URL) async -> CustomAudioAsset? {
         let didAccess = sourceURL.startAccessingSecurityScopedResource()
         defer {
             if didAccess {
@@ -124,8 +126,8 @@ internal class AudioManager: ObservableObject {
         }
 
         do {
-            let asset = try customAudioLibrary.importAudio(from: sourceURL)
-            reloadCustomAssets()
+            let asset = try await customAudioLibrary.importAudio(from: sourceURL)
+            await reloadCustomAssets()
             audioError = nil
             return asset
         } catch {
@@ -134,17 +136,17 @@ internal class AudioManager: ObservableObject {
         }
     }
 
-    func removeCustomAudio(_ asset: CustomAudioAsset) {
+    func removeCustomAudio(_ asset: CustomAudioAsset) async {
         do {
             if selectedSound == .custom(asset) {
                 stop()
             }
-            try customAudioLibrary.remove(asset)
-            reloadCustomAssets()
+            try await customAudioLibrary.remove(asset)
+            await reloadCustomAssets()
             audioError = nil
         } catch {
             report(error)
-            reloadCustomAssets()
+            await reloadCustomAssets()
         }
     }
 
@@ -224,13 +226,15 @@ internal class AudioManager: ObservableObject {
             let message = "Oak could not play \(asset.name). The file may be missing or invalid."
             logger.error("Custom audio failed: \(error.localizedDescription, privacy: .public)")
             handlePlaybackError(message)
-            reloadCustomAssets()
+            Task { [weak self] in
+                await self?.reloadCustomAssets()
+            }
         }
     }
 
-    private func reloadCustomAssets() {
+    private func reloadCustomAssets() async {
         do {
-            customAssets = try customAudioLibrary.assets()
+            customAssets = try await customAudioLibrary.assets()
         } catch {
             report(error)
         }

--- a/Oak/Oak/Services/AudioManager.swift
+++ b/Oak/Oak/Services/AudioManager.swift
@@ -7,7 +7,9 @@ import os
 
 @MainActor
 internal class AudioManager: ObservableObject {
-    @Published var selectedTrack: AudioTrack = .none
+    @Published var selectedSound: AudioSelection = .builtIn(.none)
+    @Published private(set) var customAssets: [CustomAudioAsset] = []
+    @Published private(set) var audioError: String?
     @Published var volume: Double = 0.5 {
         didSet {
             updateAudioEngineVolume()
@@ -16,16 +18,32 @@ internal class AudioManager: ObservableObject {
 
     @Published var isPlaying: Bool = false
 
+    var selectedTrack: AudioTrack {
+        guard case let .builtIn(track) = selectedSound else { return .none }
+        return track
+    }
+
     private var audioPlayer: AVAudioPlayer?
     private let ambientPlayback: AmbientAudioPlayback
+    private let customAudioLibrary: CustomAudioLibrary
     private let logger = Logger(subsystem: "com.productsway.oak.app", category: "AudioManager")
 
-    init(audioEngineFactory: @escaping () -> any AudioEngineControlling = { AudioEngineAdapter() }) {
+    init(
+        audioEngineFactory: @escaping () -> any AudioEngineControlling = { AudioEngineAdapter() },
+        customAudioLibrary: CustomAudioLibrary = CustomAudioLibrary()
+    ) {
         ambientPlayback = AmbientAudioPlayback(audioEngineFactory: audioEngineFactory)
+        self.customAudioLibrary = customAudioLibrary
+        reloadCustomAssets()
     }
 
     func play(track: AudioTrack) {
-        guard track != .none else {
+        play(sound: .builtIn(track))
+    }
+
+    func play(sound: AudioSelection) {
+        audioError = nil
+        guard !sound.isNone else {
             stop()
             return
         }
@@ -39,11 +57,15 @@ internal class AudioManager: ObservableObject {
             }
         #endif
 
-        if playBundledTrack(track) {
-            return
+        switch sound {
+        case let .builtIn(track):
+            if playBundledTrack(track) {
+                return
+            }
+            generateAmbientSound(for: track)
+        case let .custom(asset):
+            playCustomAsset(asset)
         }
-
-        generateAmbientSound(for: track)
     }
 
     /// Pauses all audio playback.
@@ -58,8 +80,11 @@ internal class AudioManager: ObservableObject {
     /// If an audio player exists, it resumes playing. Otherwise, starts the audio engine.
     func resume() {
         if let player = audioPlayer {
-            player.play()
-            isPlaying = true
+            if player.play() {
+                isPlaying = true
+            } else {
+                handlePlaybackError("Oak could not resume this sound.")
+            }
             return
         }
 
@@ -77,7 +102,7 @@ internal class AudioManager: ObservableObject {
         audioPlayer = nil
 
         isPlaying = false
-        selectedTrack = .none
+        selectedSound = .builtIn(.none)
     }
 
     private func updateAudioEngineVolume() {
@@ -87,6 +112,40 @@ internal class AudioManager: ObservableObject {
 
     func setVolume(_ newVolume: Double) {
         volume = max(0, min(1, newVolume))
+    }
+
+    @discardableResult
+    func importCustomAudio(from sourceURL: URL) -> CustomAudioAsset? {
+        let didAccess = sourceURL.startAccessingSecurityScopedResource()
+        defer {
+            if didAccess {
+                sourceURL.stopAccessingSecurityScopedResource()
+            }
+        }
+
+        do {
+            let asset = try customAudioLibrary.importAudio(from: sourceURL)
+            reloadCustomAssets()
+            audioError = nil
+            return asset
+        } catch {
+            report(error)
+            return nil
+        }
+    }
+
+    func removeCustomAudio(_ asset: CustomAudioAsset) {
+        do {
+            if selectedSound == .custom(asset) {
+                stop()
+            }
+            try customAudioLibrary.remove(asset)
+            reloadCustomAssets()
+            audioError = nil
+        } catch {
+            report(error)
+            reloadCustomAssets()
+        }
     }
 
     private func playBundledTrack(_ track: AudioTrack) -> Bool {
@@ -106,7 +165,7 @@ internal class AudioManager: ObservableObject {
 
             audioPlayer = player
             isPlaying = true
-            selectedTrack = track
+            selectedSound = .builtIn(track)
             return true
         } catch {
             let trackName = track.rawValue
@@ -137,12 +196,56 @@ internal class AudioManager: ObservableObject {
         guard ambientPlayback.play(track: track, volume: volume) else {
             logger.error("Failed to start ambient audio")
             isPlaying = false
-            selectedTrack = .none
+            selectedSound = .builtIn(.none)
             return
         }
 
         isPlaying = true
-        selectedTrack = track
+        selectedSound = .builtIn(track)
+    }
+
+    private func playCustomAsset(_ asset: CustomAudioAsset) {
+        stop()
+
+        do {
+            let player = try AVAudioPlayer(contentsOf: asset.url)
+            player.numberOfLoops = -1
+            player.volume = Float(volume)
+            player.prepareToPlay()
+            guard player.play() else {
+                handlePlaybackError("Oak could not play \(asset.name).")
+                return
+            }
+
+            audioPlayer = player
+            isPlaying = true
+            selectedSound = .custom(asset)
+        } catch {
+            let message = "Oak could not play \(asset.name). The file may be missing or invalid."
+            logger.error("Custom audio failed: \(error.localizedDescription, privacy: .public)")
+            handlePlaybackError(message)
+            reloadCustomAssets()
+        }
+    }
+
+    private func reloadCustomAssets() {
+        do {
+            customAssets = try customAudioLibrary.assets()
+        } catch {
+            report(error)
+        }
+    }
+
+    private func report(_ error: any Error) {
+        let message = error.localizedDescription
+        audioError = message
+        logger.error("Custom audio library error: \(message, privacy: .public)")
+    }
+
+    private func handlePlaybackError(_ message: String) {
+        stop()
+        audioError = message
+        logger.error("\(message, privacy: .public)")
     }
 
     deinit {

--- a/Oak/Oak/Services/CustomAudioLibrary.swift
+++ b/Oak/Oak/Services/CustomAudioLibrary.swift
@@ -9,7 +9,7 @@ internal enum CustomAudioLibraryError: LocalizedError, Equatable {
     internal var errorDescription: String? {
         switch self {
         case .unsupportedFormat:
-            "Choose an M4A, WAV, MP3, AAC, AIFF, or CAF audio file."
+            "Choose an M4A, WAV, MP3, AAC, AIFF, AIF, or CAF audio file."
         case .invalidAudio:
             "Oak could not read this audio file."
         case .outsideLibrary:
@@ -18,8 +18,8 @@ internal enum CustomAudioLibraryError: LocalizedError, Equatable {
     }
 }
 
-internal final class CustomAudioLibrary {
-    internal typealias AudioValidator = (URL) -> Bool
+internal actor CustomAudioLibrary {
+    internal typealias AudioValidator = @Sendable (URL) -> Bool
 
     private let directoryURL: URL
     private let fileManager: FileManager

--- a/Oak/Oak/Services/CustomAudioLibrary.swift
+++ b/Oak/Oak/Services/CustomAudioLibrary.swift
@@ -1,0 +1,102 @@
+import AVFoundation
+import Foundation
+
+internal enum CustomAudioLibraryError: LocalizedError, Equatable {
+    case unsupportedFormat
+    case invalidAudio
+    case outsideLibrary
+
+    internal var errorDescription: String? {
+        switch self {
+        case .unsupportedFormat:
+            "Choose an M4A, WAV, MP3, AAC, AIFF, or CAF audio file."
+        case .invalidAudio:
+            "Oak could not read this audio file."
+        case .outsideLibrary:
+            "Oak can remove only files in your personal sound library."
+        }
+    }
+}
+
+internal final class CustomAudioLibrary {
+    internal typealias AudioValidator = (URL) -> Bool
+
+    private let directoryURL: URL
+    private let fileManager: FileManager
+    private let audioValidator: AudioValidator
+
+    internal init(
+        directoryURL: URL? = nil,
+        fileManager: FileManager = .default,
+        audioValidator: @escaping AudioValidator = { CustomAudioLibrary.isPlayableAudio(at: $0) }
+    ) {
+        self.fileManager = fileManager
+        self.audioValidator = audioValidator
+        self.directoryURL = directoryURL ?? fileManager.urls(
+            for: .applicationSupportDirectory,
+            in: .userDomainMask
+        )[0]
+        .appendingPathComponent("Oak", isDirectory: true)
+        .appendingPathComponent("Sounds", isDirectory: true)
+    }
+
+    internal func assets() throws -> [CustomAudioAsset] {
+        try createDirectoryIfNeeded()
+        return try fileManager.contentsOfDirectory(
+            at: directoryURL,
+            includingPropertiesForKeys: [.isRegularFileKey],
+            options: [.skipsHiddenFiles]
+        )
+        .filter { url in
+            AudioTrack.supportedAudioExtensions.contains(url.pathExtension.lowercased())
+                && (try? url.resourceValues(forKeys: [.isRegularFileKey]).isRegularFile) == true
+        }
+        .map(CustomAudioAsset.init(url:))
+        .sorted { $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending }
+    }
+
+    internal func importAudio(from sourceURL: URL) throws -> CustomAudioAsset {
+        guard AudioTrack.supportedAudioExtensions.contains(sourceURL.pathExtension.lowercased()) else {
+            throw CustomAudioLibraryError.unsupportedFormat
+        }
+        guard audioValidator(sourceURL) else {
+            throw CustomAudioLibraryError.invalidAudio
+        }
+
+        try createDirectoryIfNeeded()
+        let destinationURL = availableDestination(for: sourceURL)
+        try fileManager.copyItem(at: sourceURL, to: destinationURL)
+        return CustomAudioAsset(url: destinationURL)
+    }
+
+    internal func remove(_ asset: CustomAudioAsset) throws {
+        let libraryPath = directoryURL.standardizedFileURL.path + "/"
+        guard asset.url.standardizedFileURL.path.hasPrefix(libraryPath) else {
+            throw CustomAudioLibraryError.outsideLibrary
+        }
+        try fileManager.removeItem(at: asset.url)
+    }
+
+    private func createDirectoryIfNeeded() throws {
+        try fileManager.createDirectory(at: directoryURL, withIntermediateDirectories: true)
+    }
+
+    private func availableDestination(for sourceURL: URL) -> URL {
+        let fileExtension = sourceURL.pathExtension
+        let baseName = sourceURL.deletingPathExtension().lastPathComponent
+        var destinationURL = directoryURL.appendingPathComponent(sourceURL.lastPathComponent)
+        var suffix = 2
+
+        while fileManager.fileExists(atPath: destinationURL.path) {
+            destinationURL = directoryURL
+                .appendingPathComponent("\(baseName) (\(suffix))")
+                .appendingPathExtension(fileExtension)
+            suffix += 1
+        }
+        return destinationURL
+    }
+
+    internal static func isPlayableAudio(at url: URL) -> Bool {
+        (try? AVAudioPlayer(contentsOf: url)) != nil
+    }
+}

--- a/Oak/Oak/Services/CustomAudioLibrary.swift
+++ b/Oak/Oak/Services/CustomAudioLibrary.swift
@@ -32,12 +32,13 @@ internal final class CustomAudioLibrary {
     ) {
         self.fileManager = fileManager
         self.audioValidator = audioValidator
-        self.directoryURL = directoryURL ?? fileManager.urls(
+        let soundsDirectory = directoryURL ?? fileManager.urls(
             for: .applicationSupportDirectory,
             in: .userDomainMask
         )[0]
         .appendingPathComponent("Oak", isDirectory: true)
         .appendingPathComponent("Sounds", isDirectory: true)
+        self.directoryURL = soundsDirectory.resolvingSymlinksInPath().standardizedFileURL
     }
 
     internal func assets() throws -> [CustomAudioAsset] {

--- a/Oak/Oak/ViewModels/FocusSessionViewModel.swift
+++ b/Oak/Oak/ViewModels/FocusSessionViewModel.swift
@@ -26,7 +26,7 @@ internal class FocusSessionViewModel: ObservableObject {
     private let currentDate: () -> Date
     private var presetSettingsCancellable: AnyCancellable?
     private var timerServiceCancellables = Set<AnyCancellable>()
-    private var lastPlayingAudioTrack: AudioTrack = .none
+    private var lastPlayingSound: AudioSelection = .builtIn(.none)
     private var wasAutoStarted: Bool = false
     let audioManager: AudioManager
     let progressManager: ProgressManager
@@ -269,8 +269,8 @@ internal extension FocusSessionViewModel {
         currentSessionStartTime = Date()
         sessionState = SessionStateMachine.start(duration: seconds, isWorkSession: interval.isWorkSession)
 
-        if interval.isWorkSession && lastPlayingAudioTrack != .none {
-            audioManager.play(track: lastPlayingAudioTrack)
+        if interval.isWorkSession && !lastPlayingSound.isNone {
+            audioManager.play(sound: lastPlayingSound)
         }
 
         timerService.start(seconds: seconds)
@@ -282,7 +282,7 @@ internal extension FocusSessionViewModel {
         currentSessionStartTime = nil
         isSessionComplete = false
         completedRounds = sessionCycle.completedRounds
-        lastPlayingAudioTrack = .none
+        lastPlayingSound = .builtIn(.none)
         wasAutoStarted = false
         audioManager.stop()
         sessionState = SessionStateMachine.reset()
@@ -306,7 +306,7 @@ internal extension FocusSessionViewModel {
         notificationService.sendSessionCompletionNotification(isWorkSession: sessionCycle.isWorkSession)
 
         if sessionCycle.isWorkSession || audioManager.isPlaying {
-            lastPlayingAudioTrack = audioManager.isPlaying ? audioManager.selectedTrack : .none
+            lastPlayingSound = audioManager.isPlaying ? audioManager.selectedSound : .builtIn(.none)
         }
 
         audioManager.stop()

--- a/Oak/Oak/Views/AudioMenuView.swift
+++ b/Oak/Oak/Views/AudioMenuView.swift
@@ -1,48 +1,56 @@
 import SwiftUI
+import UniformTypeIdentifiers
 
 internal struct AudioMenuView: View {
     @ObservedObject var audioManager: AudioManager
+    @State private var isImporting = false
+    @State private var importError: String?
 
     var body: some View {
-        VStack(spacing: 16) {
-            Text("Ambient Sound")
+        VStack(alignment: .leading, spacing: 14) {
+            Text("Sound Library")
                 .font(.headline)
-                .padding(.top, 8)
 
-            VStack(spacing: 8) {
-                ForEach(AudioTrack.allCases) { track in
-                    Button(
-                        action: {
-                            if audioManager.selectedTrack == track {
-                                audioManager.stop()
-                            } else {
-                                audioManager.play(track: track)
-                            }
-                        },
-                        label: {
-                            HStack {
-                                Image(systemName: track.systemImageName)
-                                    .frame(width: 24)
-                                Text(track.rawValue)
-                                    .font(.body)
-                                Spacer()
-                                if audioManager.selectedTrack == track && audioManager.isPlaying {
-                                    Image(systemName: "speaker.wave.2.fill")
-                                        .foregroundColor(.blue)
-                                }
-                            }
-                            .foregroundColor(.primary)
-                            .padding(.horizontal, 8)
-                            .padding(.vertical, 6)
-                            .background(audioManager.selectedTrack == track ? Color.blue.opacity(0.1) : Color.clear)
-                            .cornerRadius(8)
+            ScrollView {
+                VStack(alignment: .leading, spacing: 14) {
+                    soundSection(title: "Built-in") {
+                        ForEach(AudioTrack.allCases) { track in
+                            soundRow(.builtIn(track))
                         }
-                    )
-                    .buttonStyle(.plain)
+                    }
+
+                    soundSection(title: "My Sounds") {
+                        if audioManager.customAssets.isEmpty {
+                            Text("Import audio to add a personal sound.")
+                                .font(.caption)
+                                .foregroundColor(.secondary)
+                                .padding(.horizontal, 8)
+                        } else {
+                            ForEach(audioManager.customAssets) { asset in
+                                soundRow(.custom(asset), removableAsset: asset)
+                            }
+                        }
+                    }
                 }
             }
+            .frame(maxHeight: 300)
 
-            VStack(spacing: 8) {
+            Button(
+                action: { isImporting = true },
+                label: {
+                    Label("Import Audio…", systemImage: "plus")
+                        .frame(maxWidth: .infinity)
+                }
+            )
+            .accessibilityHint("Copies an audio file into your personal Oak sound library")
+
+            if let error = importError ?? audioManager.audioError {
+                Text(error)
+                    .font(.caption)
+                    .foregroundColor(.red)
+            }
+
+            VStack(spacing: 6) {
                 HStack {
                     Image(systemName: "speaker.fill")
                         .foregroundColor(.secondary)
@@ -58,9 +66,88 @@ internal struct AudioMenuView: View {
                     .font(.caption)
                     .foregroundColor(.secondary)
             }
-
-            Spacer()
         }
         .padding()
+        .fileImporter(
+            isPresented: $isImporting,
+            allowedContentTypes: [.audio],
+            allowsMultipleSelection: false
+        ) { result in
+            do {
+                guard let sourceURL = try result.get().first else { return }
+                importError = nil
+                if let asset = audioManager.importCustomAudio(from: sourceURL) {
+                    audioManager.play(sound: .custom(asset))
+                }
+            } catch {
+                importError = error.localizedDescription
+            }
+        }
+    }
+
+    private func soundSection<Content: View>(
+        title: String,
+        @ViewBuilder content: () -> Content
+    ) -> some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text(title.uppercased())
+                .font(.caption2.weight(.semibold))
+                .foregroundColor(.secondary)
+                .padding(.horizontal, 8)
+            content()
+        }
+    }
+
+    private func soundRow(
+        _ sound: AudioSelection,
+        removableAsset: CustomAudioAsset? = nil
+    ) -> some View {
+        let isSelected = audioManager.selectedSound == sound
+
+        return HStack(spacing: 4) {
+            Button(
+                action: {
+                    if isSelected && audioManager.isPlaying {
+                        audioManager.stop()
+                    } else {
+                        audioManager.play(sound: sound)
+                    }
+                },
+                label: {
+                    HStack {
+                        Image(systemName: sound.systemImageName)
+                            .frame(width: 24)
+                        Text(sound.name)
+                            .font(.body)
+                            .lineLimit(1)
+                        Spacer()
+                        if isSelected && audioManager.isPlaying {
+                            Image(systemName: "speaker.wave.2.fill")
+                                .foregroundColor(.blue)
+                        }
+                    }
+                    .foregroundColor(.primary)
+                    .padding(.horizontal, 8)
+                    .padding(.vertical, 6)
+                    .background(isSelected ? Color.blue.opacity(0.1) : Color.clear)
+                    .cornerRadius(8)
+                }
+            )
+            .buttonStyle(.plain)
+            .accessibilityLabel(isSelected && audioManager.isPlaying ? "Stop \(sound.name)" : "Play \(sound.name)")
+
+            if let removableAsset {
+                Button(
+                    action: { audioManager.removeCustomAudio(removableAsset) },
+                    label: {
+                        Image(systemName: "trash")
+                            .foregroundColor(.secondary)
+                    }
+                )
+                .buttonStyle(.plain)
+                .accessibilityLabel("Remove \(removableAsset.name)")
+                .help("Remove from My Sounds")
+            }
+        }
     }
 }

--- a/Oak/Oak/Views/AudioMenuView.swift
+++ b/Oak/Oak/Views/AudioMenuView.swift
@@ -3,7 +3,7 @@ import UniformTypeIdentifiers
 
 internal struct AudioMenuView: View {
     @ObservedObject var audioManager: AudioManager
-    @State private var isImporting = false
+    @Binding var isImporting: Bool
     @State private var importError: String?
 
     var body: some View {
@@ -82,9 +82,21 @@ internal struct AudioMenuView: View {
                     }
                 }
             } catch {
-                importError = error.localizedDescription
+                importError = Self.importErrorMessage(for: error)
             }
         }
+    }
+
+    internal static func importErrorMessage(for error: any Error) -> String? {
+        if error is CancellationError {
+            return nil
+        }
+
+        let cocoaError = error as NSError
+        guard cocoaError.domain != NSCocoaErrorDomain || cocoaError.code != NSUserCancelledError else {
+            return nil
+        }
+        return error.localizedDescription
     }
 
     private func soundSection<Content: View>(

--- a/Oak/Oak/Views/AudioMenuView.swift
+++ b/Oak/Oak/Views/AudioMenuView.swift
@@ -76,8 +76,10 @@ internal struct AudioMenuView: View {
             do {
                 guard let sourceURL = try result.get().first else { return }
                 importError = nil
-                if let asset = audioManager.importCustomAudio(from: sourceURL) {
-                    audioManager.play(sound: .custom(asset))
+                Task {
+                    if let asset = await audioManager.importCustomAudio(from: sourceURL) {
+                        audioManager.play(sound: .custom(asset))
+                    }
                 }
             } catch {
                 importError = error.localizedDescription
@@ -138,7 +140,11 @@ internal struct AudioMenuView: View {
 
             if let removableAsset {
                 Button(
-                    action: { audioManager.removeCustomAudio(removableAsset) },
+                    action: {
+                        Task {
+                            await audioManager.removeCustomAudio(removableAsset)
+                        }
+                    },
                     label: {
                         Image(systemName: "trash")
                             .foregroundColor(.secondary)

--- a/Oak/Oak/Views/NotchCompanionView.swift
+++ b/Oak/Oak/Views/NotchCompanionView.swift
@@ -172,7 +172,7 @@ extension NotchCompanionView {
                         )
                         .frame(width: controlSize, height: controlSize)
 
-                    Image(systemName: viewModel.audioManager.selectedTrack.systemImageName)
+                    Image(systemName: viewModel.audioManager.selectedSound.systemImageName)
                         .foregroundColor(viewModel.audioManager.isPlaying ? .blue : .white.opacity(0.7))
                         .font(.system(size: 9))
                 }
@@ -184,7 +184,7 @@ extension NotchCompanionView {
         .accessibilityIdentifier("audioButton")
         .popover(isPresented: $showAudioMenu) {
             AudioMenuView(audioManager: viewModel.audioManager)
-                .frame(width: 200)
+                .frame(width: 280)
                 .dismissOnClickOutside { [self] in
                     showAudioMenu = false
                 }

--- a/Oak/Oak/Views/NotchCompanionView.swift
+++ b/Oak/Oak/Views/NotchCompanionView.swift
@@ -7,6 +7,7 @@ internal struct NotchCompanionView: View {
     @ObservedObject private var sparkleUpdater: SparkleUpdater
     private let keyboardShortcutService: KeyboardShortcutService // Passed through; not observed here
     @State var showAudioMenu = false
+    @State var isAudioImporterPresented = false
     @State var showProgressMenu = false
     @State var showSettingsMenu = false
     @State private var animateCompletion: Bool = false
@@ -183,9 +184,12 @@ extension NotchCompanionView {
         .accessibilityHint("Opens audio menu to select ambient sounds")
         .accessibilityIdentifier("audioButton")
         .popover(isPresented: $showAudioMenu) {
-            AudioMenuView(audioManager: viewModel.audioManager)
+            AudioMenuView(
+                audioManager: viewModel.audioManager,
+                isImporting: $isAudioImporterPresented
+            )
                 .frame(width: 280)
-                .dismissOnClickOutside { [self] in
+                .dismissOnClickOutside(isDismissalSuppressed: $isAudioImporterPresented) { [self] in
                     showAudioMenu = false
                 }
         }

--- a/Oak/Oak/Views/TransientPopover.swift
+++ b/Oak/Oak/Views/TransientPopover.swift
@@ -2,10 +2,23 @@ import AppKit
 import SwiftUI
 
 internal struct ClickOutsideModifier: ViewModifier {
+    let isDismissalSuppressed: Binding<Bool>
     let action: () -> Void
     @State private var monitor: Any?
     @State private var localMonitor: Any?
     @State private var popoverWindow: NSWindow?
+
+    internal init(
+        isDismissalSuppressed: Binding<Bool> = .constant(false),
+        action: @escaping () -> Void
+    ) {
+        self.isDismissalSuppressed = isDismissalSuppressed
+        self.action = action
+    }
+
+    internal var isDismissalEnabled: Bool {
+        !isDismissalSuppressed.wrappedValue
+    }
 
     private struct WindowAccessor: NSViewRepresentable {
         @Binding var window: NSWindow?
@@ -32,7 +45,7 @@ internal struct ClickOutsideModifier: ViewModifier {
                 guard monitor == nil, localMonitor == nil else { return }
 
                 monitor = NSEvent.addGlobalMonitorForEvents(matching: [.leftMouseDown, .rightMouseDown]) { _ in
-                    guard let popoverWindow else { return }
+                    guard isDismissalEnabled, let popoverWindow else { return }
 
                     if !popoverWindow.frame.contains(NSEvent.mouseLocation) {
                         DispatchQueue.main.async {
@@ -42,7 +55,7 @@ internal struct ClickOutsideModifier: ViewModifier {
                 }
 
                 let localEventMonitor: (NSEvent) -> NSEvent = { [popoverWindow] event in
-                    guard let popoverWindow else { return event }
+                    guard isDismissalEnabled, let popoverWindow else { return event }
 
                     if event.window != popoverWindow {
                         DispatchQueue.main.async {
@@ -71,7 +84,10 @@ internal struct ClickOutsideModifier: ViewModifier {
 }
 
 internal extension View {
-    func dismissOnClickOutside(action: @escaping () -> Void) -> some View {
-        modifier(ClickOutsideModifier(action: action))
+    func dismissOnClickOutside(
+        isDismissalSuppressed: Binding<Bool> = .constant(false),
+        action: @escaping () -> Void
+    ) -> some View {
+        modifier(ClickOutsideModifier(isDismissalSuppressed: isDismissalSuppressed, action: action))
     }
 }

--- a/Oak/Tests/OakTests/AudioManagerTests.swift
+++ b/Oak/Tests/OakTests/AudioManagerTests.swift
@@ -141,14 +141,24 @@ internal final class NoiseGeneratorTests: XCTestCase {
 @MainActor
 internal final class AudioManagerTests: XCTestCase {
     var manager: AudioManager!
+    private var customAudioDirectory: URL!
 
     override func setUp() async throws {
-        manager = AudioManager()
+        customAudioDirectory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("AudioManagerTests-\(UUID().uuidString)", isDirectory: true)
+        manager = AudioManager(
+            customAudioLibrary: CustomAudioLibrary(
+                directoryURL: customAudioDirectory,
+                audioValidator: { _ in true }
+            )
+        )
     }
 
     override func tearDown() async throws {
         manager.stop()
         manager = nil
+        try? FileManager.default.removeItem(at: customAudioDirectory)
+        customAudioDirectory = nil
     }
 
     // MARK: - Volume Control
@@ -195,6 +205,31 @@ internal final class AudioManagerTests: XCTestCase {
         manager.play(track: .brownNoise)
         manager.play(track: .forest)
         XCTAssertEqual(manager.selectedTrack, .forest)
+    }
+
+    func testImportAndRemoveCustomAudio() throws {
+        let sourceURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("AudioManagerTests-source-\(UUID().uuidString).mp3")
+        try Data("test audio".utf8).write(to: sourceURL)
+        defer { try? FileManager.default.removeItem(at: sourceURL) }
+
+        let imported = try XCTUnwrap(manager.importCustomAudio(from: sourceURL))
+
+        XCTAssertEqual(manager.customAssets, [imported])
+        manager.removeCustomAudio(imported)
+        XCTAssertEqual(manager.customAssets, [])
+    }
+
+    func testMissingCustomAudioShowsErrorAndStopsPlayback() {
+        let missingAsset = CustomAudioAsset(
+            url: customAudioDirectory.appendingPathComponent("Missing.mp3")
+        )
+
+        manager.play(sound: .custom(missingAsset))
+
+        XCTAssertFalse(manager.isPlaying)
+        XCTAssertTrue(manager.selectedSound.isNone)
+        XCTAssertNotNil(manager.audioError)
     }
 
     // MARK: - Stop

--- a/Oak/Tests/OakTests/AudioManagerTests.swift
+++ b/Oak/Tests/OakTests/AudioManagerTests.swift
@@ -204,16 +204,17 @@ internal final class AudioManagerTests: XCTestCase {
         XCTAssertEqual(manager.selectedTrack, .forest)
     }
 
-    func testImportAndRemoveCustomAudio() throws {
+    func testImportAndRemoveCustomAudio() async throws {
         let sourceURL = FileManager.default.temporaryDirectory
             .appendingPathComponent("AudioManagerTests-source-\(UUID().uuidString).mp3")
         try Data("test audio".utf8).write(to: sourceURL)
         defer { try? FileManager.default.removeItem(at: sourceURL) }
 
-        let imported = try XCTUnwrap(manager.importCustomAudio(from: sourceURL))
+        let importResult = await manager.importCustomAudio(from: sourceURL)
+        let imported = try XCTUnwrap(importResult)
 
         XCTAssertEqual(manager.customAssets, [imported])
-        manager.removeCustomAudio(imported)
+        await manager.removeCustomAudio(imported)
         XCTAssertEqual(manager.customAssets, [])
     }
 

--- a/Oak/Tests/OakTests/AudioManagerTests.swift
+++ b/Oak/Tests/OakTests/AudioManagerTests.swift
@@ -147,10 +147,7 @@ internal final class AudioManagerTests: XCTestCase {
         customAudioDirectory = FileManager.default.temporaryDirectory
             .appendingPathComponent("AudioManagerTests-\(UUID().uuidString)", isDirectory: true)
         manager = AudioManager(
-            customAudioLibrary: CustomAudioLibrary(
-                directoryURL: customAudioDirectory,
-                audioValidator: { _ in true }
-            )
+            customAudioLibrary: CustomAudioLibrary(directoryURL: customAudioDirectory) { _ in true }
         )
     }
 

--- a/Oak/Tests/OakTests/AudioPersistenceTests.swift
+++ b/Oak/Tests/OakTests/AudioPersistenceTests.swift
@@ -129,6 +129,24 @@ internal final class AudioPersistenceTests: XCTestCase {
         XCTAssertEqual(viewModel.audioManager.selectedTrack, .cafe)
     }
 
+    func testCustomAudioPersistsAcrossWorkSessions() {
+        let customSound = AudioSelection.custom(
+            CustomAudioAsset(url: URL(fileURLWithPath: "/tmp/Ocean.mp3"))
+        )
+        viewModel.startSession()
+        viewModel.audioManager.play(sound: customSound)
+
+        viewModel.completeSession()
+        viewModel.startNextSession()
+        XCTAssertFalse(viewModel.audioManager.isPlaying)
+
+        viewModel.completeSession()
+        viewModel.startNextSession()
+
+        XCTAssertTrue(viewModel.audioManager.isPlaying)
+        XCTAssertEqual(viewModel.audioManager.selectedSound, customSound)
+    }
+
     func testStoppingAudioMidSessionDoesNotResumeAutomatically() {
         viewModel.startSession()
         viewModel.audioManager.play(track: .rain)

--- a/Oak/Tests/OakTests/ClickOutsideModifierTests.swift
+++ b/Oak/Tests/OakTests/ClickOutsideModifierTests.swift
@@ -23,6 +23,19 @@ internal final class ClickOutsideModifierTests: XCTestCase {
         XCTAssertFalse(wasCalled)
     }
 
+    func testDismissalIsDisabledWhilePresentedWindowRequiresInteraction() {
+        var isSuppressed = false
+        let binding = Binding(
+            get: { isSuppressed },
+            set: { isSuppressed = $0 }
+        )
+        let modifier = ClickOutsideModifier(isDismissalSuppressed: binding) {}
+
+        XCTAssertTrue(modifier.isDismissalEnabled)
+        isSuppressed = true
+        XCTAssertFalse(modifier.isDismissalEnabled)
+    }
+
     // MARK: - View Type Compatibility
 
     func testModifierCanBeAppliedToText() {
@@ -87,5 +100,25 @@ internal final class ClickOutsideModifierTests: XCTestCase {
             .dismissOnClickOutside {}
             .dismissOnClickOutside {}
         XCTAssertNotNil(view)
+    }
+}
+
+@MainActor
+internal final class AudioMenuViewTests: XCTestCase {
+    func testImportCancellationDoesNotShowError() {
+        XCTAssertNil(AudioMenuView.importErrorMessage(for: CancellationError()))
+
+        let cocoaCancellation = NSError(domain: NSCocoaErrorDomain, code: NSUserCancelledError)
+        XCTAssertNil(AudioMenuView.importErrorMessage(for: cocoaCancellation))
+    }
+
+    func testImportFailureShowsError() {
+        let failure = NSError(
+            domain: "AudioMenuViewTests",
+            code: 1,
+            userInfo: [NSLocalizedDescriptionKey: "Import failed"]
+        )
+
+        XCTAssertEqual(AudioMenuView.importErrorMessage(for: failure), "Import failed")
     }
 }

--- a/Oak/Tests/OakTests/CustomAudioLibraryTests.swift
+++ b/Oak/Tests/OakTests/CustomAudioLibraryTests.swift
@@ -1,0 +1,95 @@
+import Foundation
+import XCTest
+@testable import Oak
+
+internal final class CustomAudioLibraryTests: XCTestCase {
+    private var rootURL: URL!
+    private var libraryURL: URL!
+    private var sourceURL: URL!
+
+    override func setUpWithError() throws {
+        rootURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("CustomAudioLibraryTests-\(UUID().uuidString)", isDirectory: true)
+        libraryURL = rootURL.appendingPathComponent("Library", isDirectory: true)
+        sourceURL = rootURL.appendingPathComponent("Sources", isDirectory: true)
+        try FileManager.default.createDirectory(at: sourceURL, withIntermediateDirectories: true)
+    }
+
+    override func tearDownWithError() throws {
+        try? FileManager.default.removeItem(at: rootURL)
+        rootURL = nil
+        libraryURL = nil
+        sourceURL = nil
+    }
+
+    func testImportCopiesAudioIntoPersistentLibrary() throws {
+        let source = try makeSource(named: "Ocean.mp3")
+        let library = makeLibrary()
+
+        let imported = try library.importAudio(from: source)
+        let reloadedAssets = try makeLibrary().assets()
+
+        XCTAssertEqual(imported.name, "Ocean")
+        XCTAssertTrue(FileManager.default.fileExists(atPath: source.path))
+        XCTAssertEqual(reloadedAssets, [imported])
+    }
+
+    func testImportKeepsBothAssetsWhenNamesMatch() throws {
+        let source = try makeSource(named: "Ocean.mp3")
+        let library = makeLibrary()
+
+        let first = try library.importAudio(from: source)
+        let second = try library.importAudio(from: source)
+
+        XCTAssertEqual(first.name, "Ocean")
+        XCTAssertEqual(second.name, "Ocean (2)")
+        XCTAssertEqual(try library.assets().count, 2)
+    }
+
+    func testImportRejectsUnsupportedFormat() throws {
+        let source = try makeSource(named: "notes.txt")
+
+        XCTAssertThrowsError(try makeLibrary().importAudio(from: source)) { error in
+            XCTAssertEqual(error as? CustomAudioLibraryError, .unsupportedFormat)
+        }
+    }
+
+    func testImportRejectsInvalidAudio() throws {
+        let source = try makeSource(named: "broken.mp3")
+        let library = CustomAudioLibrary(directoryURL: libraryURL, audioValidator: { _ in false })
+
+        XCTAssertThrowsError(try library.importAudio(from: source)) { error in
+            XCTAssertEqual(error as? CustomAudioLibraryError, .invalidAudio)
+        }
+        XCTAssertEqual(try library.assets(), [])
+    }
+
+    func testRemoveDeletesManagedCopy() throws {
+        let library = makeLibrary()
+        let asset = try library.importAudio(from: makeSource(named: "Ocean.mp3"))
+
+        try library.remove(asset)
+
+        XCTAssertFalse(FileManager.default.fileExists(atPath: asset.url.path))
+        XCTAssertEqual(try library.assets(), [])
+    }
+
+    func testRemoveRejectsFileOutsideLibrary() throws {
+        let source = try makeSource(named: "Ocean.mp3")
+
+        XCTAssertThrowsError(try makeLibrary().remove(CustomAudioAsset(url: source))) { error in
+            XCTAssertEqual(error as? CustomAudioLibraryError, .outsideLibrary)
+        }
+        XCTAssertTrue(FileManager.default.fileExists(atPath: source.path))
+    }
+
+    private func makeLibrary() -> CustomAudioLibrary {
+        CustomAudioLibrary(directoryURL: libraryURL, audioValidator: { _ in true })
+    }
+
+    private func makeSource(named name: String) throws -> URL {
+        let url = sourceURL.appendingPathComponent(name)
+        try Data("test audio".utf8).write(to: url)
+        return url
+    }
+}

--- a/Oak/Tests/OakTests/CustomAudioLibraryTests.swift
+++ b/Oak/Tests/OakTests/CustomAudioLibraryTests.swift
@@ -22,62 +22,74 @@ internal final class CustomAudioLibraryTests: XCTestCase {
         sourceURL = nil
     }
 
-    func testImportCopiesAudioIntoPersistentLibrary() throws {
+    func testImportCopiesAudioIntoPersistentLibrary() async throws {
         let source = try makeSource(named: "Ocean.mp3")
         let library = makeLibrary()
 
-        let imported = try library.importAudio(from: source)
-        let reloadedAssets = try makeLibrary().assets()
+        let imported = try await library.importAudio(from: source)
+        let reloadedAssets = try await makeLibrary().assets()
 
         XCTAssertEqual(imported.name, "Ocean")
         XCTAssertTrue(FileManager.default.fileExists(atPath: source.path))
         XCTAssertEqual(reloadedAssets, [imported])
     }
 
-    func testImportKeepsBothAssetsWhenNamesMatch() throws {
+    func testImportKeepsBothAssetsWhenNamesMatch() async throws {
         let source = try makeSource(named: "Ocean.mp3")
         let library = makeLibrary()
 
-        let first = try library.importAudio(from: source)
-        let second = try library.importAudio(from: source)
+        let first = try await library.importAudio(from: source)
+        let second = try await library.importAudio(from: source)
 
         XCTAssertEqual(first.name, "Ocean")
         XCTAssertEqual(second.name, "Ocean (2)")
-        XCTAssertEqual(try library.assets().count, 2)
+        let assets = try await library.assets()
+        XCTAssertEqual(assets.count, 2)
     }
 
-    func testImportRejectsUnsupportedFormat() throws {
+    func testImportRejectsUnsupportedFormat() async throws {
         let source = try makeSource(named: "notes.txt")
 
-        XCTAssertThrowsError(try makeLibrary().importAudio(from: source)) { error in
+        do {
+            _ = try await makeLibrary().importAudio(from: source)
+            XCTFail("Import should reject unsupported formats")
+        } catch {
             XCTAssertEqual(error as? CustomAudioLibraryError, .unsupportedFormat)
         }
     }
 
-    func testImportRejectsInvalidAudio() throws {
+    func testImportRejectsInvalidAudio() async throws {
         let source = try makeSource(named: "broken.mp3")
         let library = CustomAudioLibrary(directoryURL: libraryURL) { _ in false }
 
-        XCTAssertThrowsError(try library.importAudio(from: source)) { error in
+        do {
+            _ = try await library.importAudio(from: source)
+            XCTFail("Import should reject invalid audio")
+        } catch {
             XCTAssertEqual(error as? CustomAudioLibraryError, .invalidAudio)
         }
-        XCTAssertEqual(try library.assets(), [])
+        let assets = try await library.assets()
+        XCTAssertEqual(assets, [])
     }
 
-    func testRemoveDeletesManagedCopy() throws {
+    func testRemoveDeletesManagedCopy() async throws {
         let library = makeLibrary()
-        let asset = try library.importAudio(from: makeSource(named: "Ocean.mp3"))
+        let asset = try await library.importAudio(from: makeSource(named: "Ocean.mp3"))
 
-        try library.remove(asset)
+        try await library.remove(asset)
 
         XCTAssertFalse(FileManager.default.fileExists(atPath: asset.url.path))
-        XCTAssertEqual(try library.assets(), [])
+        let assets = try await library.assets()
+        XCTAssertEqual(assets, [])
     }
 
-    func testRemoveRejectsFileOutsideLibrary() throws {
+    func testRemoveRejectsFileOutsideLibrary() async throws {
         let source = try makeSource(named: "Ocean.mp3")
 
-        XCTAssertThrowsError(try makeLibrary().remove(CustomAudioAsset(url: source))) { error in
+        do {
+            try await makeLibrary().remove(CustomAudioAsset(url: source))
+            XCTFail("Remove should reject files outside the library")
+        } catch {
             XCTAssertEqual(error as? CustomAudioLibraryError, .outsideLibrary)
         }
         XCTAssertTrue(FileManager.default.fileExists(atPath: source.path))

--- a/Oak/Tests/OakTests/CustomAudioLibraryTests.swift
+++ b/Oak/Tests/OakTests/CustomAudioLibraryTests.swift
@@ -56,7 +56,7 @@ internal final class CustomAudioLibraryTests: XCTestCase {
 
     func testImportRejectsInvalidAudio() throws {
         let source = try makeSource(named: "broken.mp3")
-        let library = CustomAudioLibrary(directoryURL: libraryURL, audioValidator: { _ in false })
+        let library = CustomAudioLibrary(directoryURL: libraryURL) { _ in false }
 
         XCTAssertThrowsError(try library.importAudio(from: source)) { error in
             XCTAssertEqual(error as? CustomAudioLibraryError, .invalidAudio)
@@ -84,7 +84,7 @@ internal final class CustomAudioLibraryTests: XCTestCase {
     }
 
     private func makeLibrary() -> CustomAudioLibrary {
-        CustomAudioLibrary(directoryURL: libraryURL, audioValidator: { _ in true })
+        CustomAudioLibrary(directoryURL: libraryURL) { _ in true }
     }
 
     private func makeSource(named name: String) throws -> URL {

--- a/Oak/Tests/OakTests/MockAudioManager.swift
+++ b/Oak/Tests/OakTests/MockAudioManager.swift
@@ -8,11 +8,15 @@ internal final class MockAudioManager: AudioManager {
     }
 
     override func play(track: AudioTrack) {
-        guard track != .none else {
+        play(sound: .builtIn(track))
+    }
+
+    override func play(sound: AudioSelection) {
+        guard !sound.isNone else {
             stop()
             return
         }
-        selectedTrack = track
+        selectedSound = sound
         isPlaying = true
     }
 
@@ -21,13 +25,13 @@ internal final class MockAudioManager: AudioManager {
     }
 
     override func resume() {
-        guard selectedTrack != .none else { return }
+        guard !selectedSound.isNone else { return }
         isPlaying = true
     }
 
     override func stop() {
         isPlaying = false
-        selectedTrack = .none
+        selectedSound = .builtIn(.none)
     }
 }
 

--- a/Oak/Tests/OakTests/NotchCompanionViewTests+Layout.swift
+++ b/Oak/Tests/OakTests/NotchCompanionViewTests+Layout.swift
@@ -8,6 +8,7 @@ internal extension NotchCompanionViewTests {
     func testShowAudioMenuDefaultsToFalse() {
         let view = makeView()
         XCTAssertFalse(view.showAudioMenu, "showAudioMenu should default to false")
+        XCTAssertFalse(view.isAudioImporterPresented, "isAudioImporterPresented should default to false")
     }
 
     func testShowProgressMenuDefaultsToFalse() {

--- a/README.md
+++ b/README.md
@@ -55,6 +55,21 @@ In today's world of constant distractions, deep work has become increasingly rar
 - 💾 **Data export**: Export your progress as JSON or CSV, or import from a backup file
 - 🔄 **Auto-update**: Seamless updates via Sparkle framework
 
+### Finding sounds to import
+
+Check the license shown for each file before you download it. Terms can change, and Oak does not track attribution
+for imported sounds.
+
+- [Pixabay Sound Effects](https://pixabay.com/sound-effects/) — Pixabay's
+  [Content License](https://pixabay.com/service/license-summary/) permits free use without attribution. It prohibits
+  standalone resale or redistribution and warns that third-party rights can still apply.
+- [Mixkit Sound Effects](https://mixkit.co/free-sound-effects/) — Mixkit states that its free sound effects can be
+  used in personal and commercial projects without attribution. Confirm that the item uses the **Sound Effects Free
+  License** on the [Mixkit license page](https://mixkit.co/license/).
+- [Freesound](https://freesound.org/browse/) — licenses vary by file. Prefer **CC0** for the fewest restrictions.
+  **CC BY** requires creator attribution, and **CC BY-NC** also prohibits commercial use. See Freesound's
+  [license and attribution guide](https://freesound.org/help/faq/#licenses).
+
 ## Installation
 
 ### Using Homebrew (Recommended)

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ In today's world of constant distractions, deep work has become increasingly rar
 - ⏱️ **Pomodoro presets**: Default `25/5` and `50/10` sessions (fully configurable)
 - 🔄 **Smart breaks**: Automatic 15/20 min long breaks after 4 focus rounds
 - ▶️ **Session controls**: Start, pause, and resume your focus sessions
-- 🎵 **Ambient sounds**: Rain, forest, cafe, brown noise, and lo-fi to help you concentrate
+- 🎵 **Sound library**: Use the built-in ambient sounds or import your own local audio files
 - ⌨️ **Keyboard shortcuts**: Press Space to start/pause/resume, Escape to reset — control sessions without touching the mouse
 - 📊 **Local tracking**: Track daily focus minutes, completed sessions, and 7-day streaks
 - 🕒 **Session timeline**: See each focus session and break from today with start/end times and durations

--- a/tasks/prd-macos-focus-companion-app.md
+++ b/tasks/prd-macos-focus-companion-app.md
@@ -56,6 +56,7 @@ This PRD defines a KISS MVP focused on a notch-based experience with minimal set
 **Acceptance Criteria:**
 
 - [ ] Built-in tracks available: rain, forest, cafe, brown noise, lo-fi.
+- [ ] User can import, select, and remove personal sounds from a local sound library.
 - [ ] User can select one track before or during session.
 - [ ] User can adjust volume from app controls.
 - [ ] Audio stops automatically when session ends.
@@ -95,6 +96,7 @@ This PRD defines a KISS MVP focused on a notch-based experience with minimal set
 - FR-7: The system must provide optional auto-start of next interval (work <-> break), default OFF in MVP.
 - FR-8: The system must not require any global keyboard shortcut in MVP.
 - FR-9: The system must include built-in ambient tracks: rain, forest, cafe, brown noise, lo-fi.
+- FR-9a: The system must let users import, select, and remove local audio files without replacing built-in tracks.
 - FR-10: The system must provide user volume control for ambient audio.
 - FR-11: The system must stop ambient audio automatically when a session ends.
 - FR-12: The system must trigger a subtle completion animation in the notch UI.
@@ -107,7 +109,7 @@ This PRD defines a KISS MVP focused on a notch-based experience with minimal set
 
 - Any distraction control in MVP (no macOS Focus mode trigger, no notification silencing controls).
 - Custom timer durations.
-- Additional or user-imported sound packs.
+- Downloadable or remotely hosted sound packs.
 - Cross-device sync.
 - Shared focus rooms or multiplayer features.
 - CLI integration.


### PR DESCRIPTION
## What

- Add a sound-library popover with separate built-in and personal sound sections
- Let users import, select, loop, adjust, and remove local audio assets
- Preserve personal sound playback across focus-session transitions
- Add storage, error-handling, transition, and manager tests
- Add concise, license-aware links to trusted free-sound sources
- Update the product and development documentation

## Why

Oak currently limits ambient audio to bundled tracks. Users need to use their own local audio while keeping the existing built-in sounds and session lifecycle behavior.

## How

- Copy validated imports into `~/Library/Application Support/Oak/Sounds` while the file-importer's security scope is active. App-managed copies avoid stale external paths and long-lived security-scoped bookmarks.
- Isolate validation, copying, removal, and directory scans in a `CustomAudioLibrary` actor so large assets do not block the notch UI.
- Represent playback as one selection that can point to a built-in track or a personal sound.
- Reuse `AVAudioPlayer` looping and volume behavior for personal sounds, while keeping generated fallback audio for missing built-in resources.
- Canonicalize managed paths, refresh the library after imports, removals, and missing-file failures, and show actionable errors in the popover.

## Checklist

- [x] Tests added or updated
- [x] Documentation updated
- [x] No breaking changes
- [x] macOS CI build, tests, and lint pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Sound Library with built-in ambient sounds and support for importing local audio files.
  * Imported sounds can be selected, played, removed, and reused across focus sessions.
  * Added support for AAC, AIFF, AIF, CAF, M4A, WAV, and MP3 files.
  * Added clear feedback for unsupported or invalid audio files.
  * Added macOS pull-request build verification and downloadable test artifacts.

* **Documentation**
  * Updated user and contributor documentation with sound-import guidance and licensing information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->