### PR TITLE
feat(theme): add selectable app themes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Added
 
-- Selectable Oak, Kanagawa, Dracula, and Tokyo Night themes with persisted app-wide colors
+- Selectable Oak, Kanagawa Wave/Lotus, Dracula/Alucard, and Tokyo Night Moon/Day themes with persisted app-wide colors
 - Keyboard shortcuts for timer control — Space to start/pause/resume, Escape to reset. Configurable in Settings with optional global hotkeys (#142)
 - Progress data export/import — Export session history as JSON or CSV, import from backup files. Data section in Settings with NSSavePanel/NSOpenPanel (#141)
 - Domain glossary (`CONTEXT.md`) — formal definitions for Session State, Preset, Round, Display Target, and other core terms

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Added
 
+- Selectable Oak, Kanagawa, Dracula, and Tokyo Night themes with persisted app-wide colors
 - Keyboard shortcuts for timer control — Space to start/pause/resume, Escape to reset. Configurable in Settings with optional global hotkeys (#142)
 - Progress data export/import — Export session history as JSON or CSV, import from backup files. Data section in Settings with NSSavePanel/NSOpenPanel (#141)
 - Domain glossary (`CONTEXT.md`) — formal definitions for Session State, Preset, Round, Display Target, and other core terms

--- a/Oak/Oak.xcodeproj/project.pbxproj
+++ b/Oak/Oak.xcodeproj/project.pbxproj
@@ -52,6 +52,9 @@
 		900E3D31705B38756E037EA1 /* AudioEngineControlling.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E7C621CDFB0A0D1B1137478 /* AudioEngineControlling.swift */; };
 		91F4096D77B5684A1251EE01 /* SupportSectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9E56FB534D3736A6E1C03BD /* SupportSectionView.swift */; };
 		935A6BD932F4EC629908FE05 /* ambient_lofi.m4a in Resources */ = {isa = PBXBuildFile; fileRef = 63539C12247302E14148BE07 /* ambient_lofi.m4a */; };
+		94A4F0A676F04096ACCA5B04 /* AppTheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94A4F0A676F04096ACCA5B01 /* AppTheme.swift */; };
+		94A4F0A676F04096ACCA5B05 /* ThemeConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94A4F0A676F04096ACCA5B02 /* ThemeConfig.swift */; };
+		94A4F0A676F04096ACCA5B06 /* ThemeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94A4F0A676F04096ACCA5B03 /* ThemeTests.swift */; };
 		98EA03D50041483DEFBB6984 /* SmokeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E00D04EC9E5E33BBF5D09F7 /* SmokeTests.swift */; };
 		A241F12DFE716A2C633FC7D0 /* MockAudioManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1B03DC457EAE4AA55E72345 /* MockAudioManager.swift */; };
 		A5A710E1728BFAC40AF7ED47 /* AppcastVersionParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 309AA6D939B204C7F18AB1DA /* AppcastVersionParserTests.swift */; };
@@ -166,6 +169,9 @@
 		85C93F37E0AC4AA71C304FDD /* US003Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = US003Tests.swift; sourceTree = "<group>"; };
 		85FAA8F73F21E099B201F0FB /* DisplayIDInitializationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DisplayIDInitializationTests.swift; sourceTree = "<group>"; };
 		8E7C621CDFB0A0D1B1137478 /* AudioEngineControlling.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioEngineControlling.swift; sourceTree = "<group>"; };
+		94A4F0A676F04096ACCA5B01 /* AppTheme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppTheme.swift; sourceTree = "<group>"; };
+		94A4F0A676F04096ACCA5B02 /* ThemeConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemeConfig.swift; sourceTree = "<group>"; };
+		94A4F0A676F04096ACCA5B03 /* ThemeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemeTests.swift; sourceTree = "<group>"; };
 		985C59F06B49B761EA5A1324 /* SessionCycle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionCycle.swift; sourceTree = "<group>"; };
 		9B4036DF213344159CE1710B /* AudioSelection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioSelection.swift; sourceTree = "<group>"; };
 		98D555E4182E199E8EC8D0B3 /* NotificationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationService.swift; sourceTree = "<group>"; };
@@ -217,6 +223,7 @@
 		01D9F58885F69FCDA63E90F6 /* Models */ = {
 			isa = PBXGroup;
 			children = (
+				94A4F0A676F04096ACCA5B01 /* AppTheme.swift */,
 				9B4036DF213344159CE1710B /* AudioSelection.swift */,
 				841F3EFAB628759B783D66D3 /* AudioTrack.swift */,
 				A53A901D48495497B38B2A1E /* CountdownDisplayMode.swift */,
@@ -311,6 +318,7 @@
 				DA71DF374BE14AAE57917F4E /* SessionTimerServiceTests.swift */,
 				0E00D04EC9E5E33BBF5D09F7 /* SmokeTests.swift */,
 				B678070C4468D7AD6171B2C2 /* SparkleUpdaterTests.swift */,
+				94A4F0A676F04096ACCA5B03 /* ThemeTests.swift */,
 				B74BB88C04B3824E97E3C561 /* US001Tests.swift */,
 				26934C0C6B7C8A90F9D57916 /* US002Tests.swift */,
 				85C93F37E0AC4AA71C304FDD /* US003Tests.swift */,
@@ -375,6 +383,7 @@
 				454BAD66455AFEFEFD7EEA79 /* SessionDurationConfig.swift */,
 				18F2F3DEA012EE98A549BC02 /* SessionTimerService.swift */,
 				770CCC886CF6A5E903159704 /* SparkleUpdater.swift */,
+				94A4F0A676F04096ACCA5B02 /* ThemeConfig.swift */,
 			);
 			path = Services;
 			sourceTree = "<group>";
@@ -490,6 +499,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				94A4F0A676F04096ACCA5B04 /* AppTheme.swift in Sources */,
 				FA8AA66B37D598BB556E27DC /* AmbientAudioPlayback.swift in Sources */,
 				900E3D31705B38756E037EA1 /* AudioEngineControlling.swift in Sources */,
 				D01FB63BF5CAA09DBAE33DD0 /* AudioManager.swift in Sources */,
@@ -531,6 +541,7 @@
 				716599FCD65FC35919E253E8 /* SettingsMenuView.swift in Sources */,
 				D9BC1320EE869D9AD7FE40AE /* SparkleUpdater.swift in Sources */,
 				91F4096D77B5684A1251EE01 /* SupportSectionView.swift in Sources */,
+				94A4F0A676F04096ACCA5B05 /* ThemeConfig.swift in Sources */,
 				11949A6E7635E4BC247D1A97 /* TransientPopover.swift in Sources */,
 				1B89D6E392D0EBFBE60F788E /* UpdateSettingsView.swift in Sources */,
 				C1240C3065D965558736AA46 /* WindowFrameUpdateCoordinator.swift in Sources */,
@@ -571,6 +582,7 @@
 				3007E12D7C9341A05443402A /* SessionTimerServiceTests.swift in Sources */,
 				98EA03D50041483DEFBB6984 /* SmokeTests.swift in Sources */,
 				088CE53BA008F2E0ED7225E3 /* SparkleUpdaterTests.swift in Sources */,
+				94A4F0A676F04096ACCA5B06 /* ThemeTests.swift in Sources */,
 				1B420ABE27C55D4F4D474075 /* US001Tests.swift in Sources */,
 				DD867AD4D9ABF04F13068B20 /* US002Tests.swift in Sources */,
 				B54A841D1308C18C226BF1C0 /* US003Tests.swift in Sources */,

--- a/Oak/Oak.xcodeproj/project.pbxproj
+++ b/Oak/Oak.xcodeproj/project.pbxproj
@@ -57,6 +57,8 @@
 		94A4F0A676F04096ACCA5B06 /* ThemeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94A4F0A676F04096ACCA5B03 /* ThemeTests.swift */; };
 		A4B5C6D7E8F9012345678901 /* KeyboardSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4B5C6D7E8F9012345678903 /* KeyboardSettingsView.swift */; };
 		A4B5C6D7E8F9012345678902 /* DataSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4B5C6D7E8F9012345678904 /* DataSettingsView.swift */; };
+		A4B5C6D7E8F9012345678905 /* SettingsWindowLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4B5C6D7E8F9012345678906 /* SettingsWindowLayout.swift */; };
+		A4B5C6D7E8F9012345678907 /* SettingsVersion.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4B5C6D7E8F9012345678908 /* SettingsVersion.swift */; };
 		98EA03D50041483DEFBB6984 /* SmokeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E00D04EC9E5E33BBF5D09F7 /* SmokeTests.swift */; };
 		A241F12DFE716A2C633FC7D0 /* MockAudioManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1B03DC457EAE4AA55E72345 /* MockAudioManager.swift */; };
 		A5A710E1728BFAC40AF7ED47 /* AppcastVersionParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 309AA6D939B204C7F18AB1DA /* AppcastVersionParserTests.swift */; };
@@ -176,6 +178,8 @@
 		94A4F0A676F04096ACCA5B03 /* ThemeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemeTests.swift; sourceTree = "<group>"; };
 		A4B5C6D7E8F9012345678903 /* KeyboardSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardSettingsView.swift; sourceTree = "<group>"; };
 		A4B5C6D7E8F9012345678904 /* DataSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataSettingsView.swift; sourceTree = "<group>"; };
+		A4B5C6D7E8F9012345678906 /* SettingsWindowLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsWindowLayout.swift; sourceTree = "<group>"; };
+		A4B5C6D7E8F9012345678908 /* SettingsVersion.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsVersion.swift; sourceTree = "<group>"; };
 		985C59F06B49B761EA5A1324 /* SessionCycle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionCycle.swift; sourceTree = "<group>"; };
 		9B4036DF213344159CE1710B /* AudioSelection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioSelection.swift; sourceTree = "<group>"; };
 		98D555E4182E199E8EC8D0B3 /* NotificationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationService.swift; sourceTree = "<group>"; };
@@ -353,6 +357,8 @@
 				EA36A47C5BB3764BB7DAD70B /* PresetEditorView.swift */,
 				D924AA0A4E1BF237979F3114 /* ProgressMenuView.swift */,
 				23364F4B016E445E5657BF63 /* SettingsMenuView.swift */,
+				A4B5C6D7E8F9012345678906 /* SettingsWindowLayout.swift */,
+				A4B5C6D7E8F9012345678908 /* SettingsVersion.swift */,
 				D9E56FB534D3736A6E1C03BD /* SupportSectionView.swift */,
 				C9239254E9493D78E223CE6D /* TransientPopover.swift */,
 				630A26F2F361CCE214543440 /* UpdateSettingsView.swift */,
@@ -545,6 +551,8 @@
 				CE3A4934C57D1C203D016F96 /* SessionModels.swift in Sources */,
 				F51DE81C4543A035DA93A6F7 /* SessionTimerService.swift in Sources */,
 				716599FCD65FC35919E253E8 /* SettingsMenuView.swift in Sources */,
+				A4B5C6D7E8F9012345678905 /* SettingsWindowLayout.swift in Sources */,
+				A4B5C6D7E8F9012345678907 /* SettingsVersion.swift in Sources */,
 				A4B5C6D7E8F9012345678902 /* DataSettingsView.swift in Sources */,
 				A4B5C6D7E8F9012345678901 /* KeyboardSettingsView.swift in Sources */,
 				D9BC1320EE869D9AD7FE40AE /* SparkleUpdater.swift in Sources */,

--- a/Oak/Oak.xcodeproj/project.pbxproj
+++ b/Oak/Oak.xcodeproj/project.pbxproj
@@ -55,6 +55,8 @@
 		94A4F0A676F04096ACCA5B04 /* AppTheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94A4F0A676F04096ACCA5B01 /* AppTheme.swift */; };
 		94A4F0A676F04096ACCA5B05 /* ThemeConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94A4F0A676F04096ACCA5B02 /* ThemeConfig.swift */; };
 		94A4F0A676F04096ACCA5B06 /* ThemeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94A4F0A676F04096ACCA5B03 /* ThemeTests.swift */; };
+		A4B5C6D7E8F9012345678901 /* KeyboardSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4B5C6D7E8F9012345678903 /* KeyboardSettingsView.swift */; };
+		A4B5C6D7E8F9012345678902 /* DataSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4B5C6D7E8F9012345678904 /* DataSettingsView.swift */; };
 		98EA03D50041483DEFBB6984 /* SmokeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E00D04EC9E5E33BBF5D09F7 /* SmokeTests.swift */; };
 		A241F12DFE716A2C633FC7D0 /* MockAudioManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1B03DC457EAE4AA55E72345 /* MockAudioManager.swift */; };
 		A5A710E1728BFAC40AF7ED47 /* AppcastVersionParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 309AA6D939B204C7F18AB1DA /* AppcastVersionParserTests.swift */; };
@@ -172,6 +174,8 @@
 		94A4F0A676F04096ACCA5B01 /* AppTheme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppTheme.swift; sourceTree = "<group>"; };
 		94A4F0A676F04096ACCA5B02 /* ThemeConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemeConfig.swift; sourceTree = "<group>"; };
 		94A4F0A676F04096ACCA5B03 /* ThemeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemeTests.swift; sourceTree = "<group>"; };
+		A4B5C6D7E8F9012345678903 /* KeyboardSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardSettingsView.swift; sourceTree = "<group>"; };
+		A4B5C6D7E8F9012345678904 /* DataSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataSettingsView.swift; sourceTree = "<group>"; };
 		985C59F06B49B761EA5A1324 /* SessionCycle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionCycle.swift; sourceTree = "<group>"; };
 		9B4036DF213344159CE1710B /* AudioSelection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioSelection.swift; sourceTree = "<group>"; };
 		98D555E4182E199E8EC8D0B3 /* NotificationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationService.swift; sourceTree = "<group>"; };
@@ -337,6 +341,8 @@
 				F3D8E840983307E12ADC1FCF /* AudioMenuView.swift */,
 				D875A8103C5D96B028D6ED5C /* CircularProgressRing.swift */,
 				F287A617D7BF92425C7BD22A /* ConfettiView.swift */,
+				A4B5C6D7E8F9012345678904 /* DataSettingsView.swift */,
+				A4B5C6D7E8F9012345678903 /* KeyboardSettingsView.swift */,
 				0679D26521D6F4E9C5774630 /* NotchCompanionView.swift */,
 				047B20E550402C5D04E55B6E /* NotchCompanionView+InsideNotch.swift */,
 				5E581D2529EA9F9B22AEB5DE /* NotchCompanionView+StandardViews.swift */,
@@ -539,6 +545,8 @@
 				CE3A4934C57D1C203D016F96 /* SessionModels.swift in Sources */,
 				F51DE81C4543A035DA93A6F7 /* SessionTimerService.swift in Sources */,
 				716599FCD65FC35919E253E8 /* SettingsMenuView.swift in Sources */,
+				A4B5C6D7E8F9012345678902 /* DataSettingsView.swift in Sources */,
+				A4B5C6D7E8F9012345678901 /* KeyboardSettingsView.swift in Sources */,
 				D9BC1320EE869D9AD7FE40AE /* SparkleUpdater.swift in Sources */,
 				91F4096D77B5684A1251EE01 /* SupportSectionView.swift in Sources */,
 				94A4F0A676F04096ACCA5B05 /* ThemeConfig.swift in Sources */,

--- a/Oak/Oak/Models/AppTheme.swift
+++ b/Oak/Oak/Models/AppTheme.swift
@@ -3,24 +3,31 @@ import SwiftUI
 internal enum AppTheme: String, CaseIterable, Identifiable {
     case oak
     case kanagawa
+    case kanagawaLotus
     case dracula
+    case alucard
     case tokyoNight
+    case tokyoNightDay
 
-    var id: String { rawValue }
+    internal var id: String { rawValue }
 
-    var displayName: String {
+    internal var displayName: String {
         switch self {
         case .oak: "Oak"
         case .kanagawa: "Kanagawa"
+        case .kanagawaLotus: "Kanagawa Lotus"
         case .dracula: "Dracula"
+        case .alucard: "Alucard (Dracula Light)"
         case .tokyoNight: "Tokyo Night"
+        case .tokyoNightDay: "Tokyo Night Day"
         }
     }
 
-    var palette: ThemePalette {
+    internal var palette: ThemePalette {
         switch self {
         case .oak:
             ThemePalette(
+                colorScheme: .dark,
                 background: Self.color(0x010105),
                 surface: Self.color(0x030305),
                 foreground: .white,
@@ -35,6 +42,7 @@ internal enum AppTheme: String, CaseIterable, Identifiable {
         case .kanagawa:
             // Wave is the default Kanagawa variant, so it is the least surprising unqualified palette.
             ThemePalette(
+                colorScheme: .dark,
                 background: Self.color(0x1F1F28),
                 surface: Self.color(0x2A2A37),
                 foreground: Self.color(0xDCD7BA),
@@ -46,32 +54,78 @@ internal enum AppTheme: String, CaseIterable, Identifiable {
                 pink: Self.color(0xD27E99),
                 yellow: Self.color(0xE6C384)
             )
+        case .kanagawaLotus:
+            // Oak uses deeper Lotus tokens where its editor defaults are too faint for compact controls.
+            ThemePalette(
+                colorScheme: .light,
+                background: Self.color(0xF2ECBC),
+                surface: Self.color(0xE5DDB0),
+                foreground: Self.color(0x43436C),
+                accent: Self.color(0x4D699B),
+                success: Self.color(0x597B75),
+                warning: Self.color(0x77713F),
+                error: Self.color(0xC84053),
+                purple: Self.color(0x624C83),
+                pink: Self.color(0xB35B79),
+                yellow: Self.color(0x77713F)
+            )
         case .dracula:
             ThemePalette(
+                colorScheme: .dark,
                 background: Self.color(0x282A36),
                 surface: Self.color(0x44475A),
                 foreground: Self.color(0xF8F8F2),
                 accent: Self.color(0x8BE9FD),
                 success: Self.color(0x50FA7B),
                 warning: Self.color(0xFFB86C),
-                error: Self.color(0xFF5555),
+                error: Self.color(0xFF6161),
                 purple: Self.color(0xBD93F9),
                 pink: Self.color(0xFF79C6),
                 yellow: Self.color(0xF1FA8C)
             )
+        case .alucard:
+            ThemePalette(
+                colorScheme: .light,
+                background: Self.color(0xFFFBEB),
+                surface: Self.color(0xCFCFDE),
+                foreground: Self.color(0x1F1F1F),
+                accent: Self.color(0x036A96),
+                success: Self.color(0x14710A),
+                warning: Self.color(0xA34D14),
+                error: Self.color(0xCB3A2A),
+                purple: Self.color(0x644AC9),
+                pink: Self.color(0xA3144D),
+                yellow: Self.color(0x846E15)
+            )
         case .tokyoNight:
             // Moon is Tokyo Night's current default and provides stronger compact-UI contrast than Night.
             ThemePalette(
+                colorScheme: .dark,
                 background: Self.color(0x222436),
                 surface: Self.color(0x2F334D),
                 foreground: Self.color(0xC8D3F5),
                 accent: Self.color(0x82AAFF),
                 success: Self.color(0xC3E88D),
                 warning: Self.color(0xFF966C),
-                error: Self.color(0xC53B53),
+                error: Self.color(0xFF757F),
                 purple: Self.color(0xFCA7EA),
                 pink: Self.color(0xC099FF),
                 yellow: Self.color(0xFFC777)
+            )
+        case .tokyoNightDay:
+            // Day's darker blue tokens keep text and actions legible on both official background shades.
+            ThemePalette(
+                colorScheme: .light,
+                background: Self.color(0xE1E2E7),
+                surface: Self.color(0xD0D5E3),
+                foreground: Self.color(0x2E5857),
+                accent: Self.color(0x006A83),
+                success: Self.color(0x587539),
+                warning: Self.color(0x8C6C3E),
+                error: Self.color(0xC64343),
+                purple: Self.color(0x7847BD),
+                pink: Self.color(0xD20065),
+                yellow: Self.color(0x8C6C3E)
             )
         }
     }
@@ -86,21 +140,22 @@ internal enum AppTheme: String, CaseIterable, Identifiable {
 }
 
 internal struct ThemePalette {
-    let background: Color
-    let surface: Color
-    let foreground: Color
-    let accent: Color
-    let success: Color
-    let warning: Color
-    let error: Color
-    let purple: Color
-    let pink: Color
-    let yellow: Color
+    internal let colorScheme: ColorScheme
+    internal let background: Color
+    internal let surface: Color
+    internal let foreground: Color
+    internal let accent: Color
+    internal let success: Color
+    internal let warning: Color
+    internal let error: Color
+    internal let purple: Color
+    internal let pink: Color
+    internal let yellow: Color
 
-    var secondaryForeground: Color { foreground.opacity(0.72) }
-    var subtleForeground: Color { foreground.opacity(0.60) }
-    var controlBackground: Color { foreground.opacity(0.16) }
-    var selectedBackground: Color { accent.opacity(0.22) }
-    var divider: Color { foreground.opacity(0.24) }
-    var confettiColors: [Color] { [success, accent, warning, pink, purple, yellow, error] }
+    internal var secondaryForeground: Color { foreground.opacity(colorScheme == .light ? 0.95 : 0.72) }
+    internal var subtleForeground: Color { foreground.opacity(colorScheme == .light ? 0.92 : 0.66) }
+    internal var controlBackground: Color { foreground.opacity(0.16) }
+    internal var selectedBackground: Color { accent.opacity(0.22) }
+    internal var divider: Color { foreground.opacity(0.24) }
+    internal var confettiColors: [Color] { [success, accent, warning, pink, purple, yellow, error] }
 }

--- a/Oak/Oak/Models/AppTheme.swift
+++ b/Oak/Oak/Models/AppTheme.swift
@@ -170,6 +170,14 @@ internal struct ThemePalette {
         accent.opacity(0.22)
     }
 
+    internal var prominentSelectedBackground: Color {
+        accent
+    }
+
+    internal var prominentSelectedForeground: Color {
+        background
+    }
+
     internal var divider: Color {
         foreground.opacity(0.24)
     }

--- a/Oak/Oak/Models/AppTheme.swift
+++ b/Oak/Oak/Models/AppTheme.swift
@@ -1,0 +1,106 @@
+import SwiftUI
+
+internal enum AppTheme: String, CaseIterable, Identifiable {
+    case oak
+    case kanagawa
+    case dracula
+    case tokyoNight
+
+    var id: String { rawValue }
+
+    var displayName: String {
+        switch self {
+        case .oak: "Oak"
+        case .kanagawa: "Kanagawa"
+        case .dracula: "Dracula"
+        case .tokyoNight: "Tokyo Night"
+        }
+    }
+
+    var palette: ThemePalette {
+        switch self {
+        case .oak:
+            ThemePalette(
+                background: Self.color(0x010105),
+                surface: Self.color(0x030305),
+                foreground: .white,
+                accent: Self.color(0x66A7FF),
+                success: Self.color(0x69D17D),
+                warning: Self.color(0xF4AA4F),
+                error: Self.color(0xFF666C),
+                purple: Self.color(0xB895F3),
+                pink: Self.color(0xF080B5),
+                yellow: Self.color(0xF4D76D)
+            )
+        case .kanagawa:
+            // Wave is the default Kanagawa variant, so it is the least surprising unqualified palette.
+            ThemePalette(
+                background: Self.color(0x1F1F28),
+                surface: Self.color(0x2A2A37),
+                foreground: Self.color(0xDCD7BA),
+                accent: Self.color(0x7E9CD8),
+                success: Self.color(0x98BB6C),
+                warning: Self.color(0xFF9E3B),
+                error: Self.color(0xE82424),
+                purple: Self.color(0x957FB8),
+                pink: Self.color(0xD27E99),
+                yellow: Self.color(0xE6C384)
+            )
+        case .dracula:
+            ThemePalette(
+                background: Self.color(0x282A36),
+                surface: Self.color(0x44475A),
+                foreground: Self.color(0xF8F8F2),
+                accent: Self.color(0x8BE9FD),
+                success: Self.color(0x50FA7B),
+                warning: Self.color(0xFFB86C),
+                error: Self.color(0xFF5555),
+                purple: Self.color(0xBD93F9),
+                pink: Self.color(0xFF79C6),
+                yellow: Self.color(0xF1FA8C)
+            )
+        case .tokyoNight:
+            // Moon is Tokyo Night's current default and provides stronger compact-UI contrast than Night.
+            ThemePalette(
+                background: Self.color(0x222436),
+                surface: Self.color(0x2F334D),
+                foreground: Self.color(0xC8D3F5),
+                accent: Self.color(0x82AAFF),
+                success: Self.color(0xC3E88D),
+                warning: Self.color(0xFF966C),
+                error: Self.color(0xC53B53),
+                purple: Self.color(0xFCA7EA),
+                pink: Self.color(0xC099FF),
+                yellow: Self.color(0xFFC777)
+            )
+        }
+    }
+
+    private static func color(_ hex: UInt32) -> Color {
+        Color(
+            red: Double((hex >> 16) & 0xFF) / 255,
+            green: Double((hex >> 8) & 0xFF) / 255,
+            blue: Double(hex & 0xFF) / 255
+        )
+    }
+}
+
+internal struct ThemePalette {
+    let background: Color
+    let surface: Color
+    let foreground: Color
+    let accent: Color
+    let success: Color
+    let warning: Color
+    let error: Color
+    let purple: Color
+    let pink: Color
+    let yellow: Color
+
+    var secondaryForeground: Color { foreground.opacity(0.72) }
+    var subtleForeground: Color { foreground.opacity(0.60) }
+    var controlBackground: Color { foreground.opacity(0.16) }
+    var selectedBackground: Color { accent.opacity(0.22) }
+    var divider: Color { foreground.opacity(0.24) }
+    var confettiColors: [Color] { [success, accent, warning, pink, purple, yellow, error] }
+}

--- a/Oak/Oak/Models/AppTheme.swift
+++ b/Oak/Oak/Models/AppTheme.swift
@@ -9,7 +9,9 @@ internal enum AppTheme: String, CaseIterable, Identifiable {
     case tokyoNight
     case tokyoNightDay
 
-    internal var id: String { rawValue }
+    internal var id: String {
+        rawValue
+    }
 
     internal var displayName: String {
         switch self {
@@ -152,10 +154,27 @@ internal struct ThemePalette {
     internal let pink: Color
     internal let yellow: Color
 
-    internal var secondaryForeground: Color { foreground.opacity(colorScheme == .light ? 0.95 : 0.72) }
-    internal var subtleForeground: Color { foreground.opacity(colorScheme == .light ? 0.92 : 0.66) }
-    internal var controlBackground: Color { foreground.opacity(0.16) }
-    internal var selectedBackground: Color { accent.opacity(0.22) }
-    internal var divider: Color { foreground.opacity(0.24) }
-    internal var confettiColors: [Color] { [success, accent, warning, pink, purple, yellow, error] }
+    internal var secondaryForeground: Color {
+        foreground.opacity(colorScheme == .light ? 0.95 : 0.72)
+    }
+
+    internal var subtleForeground: Color {
+        foreground.opacity(colorScheme == .light ? 0.92 : 0.66)
+    }
+
+    internal var controlBackground: Color {
+        foreground.opacity(0.16)
+    }
+
+    internal var selectedBackground: Color {
+        accent.opacity(0.22)
+    }
+
+    internal var divider: Color {
+        foreground.opacity(0.24)
+    }
+
+    internal var confettiColors: [Color] {
+        [success, accent, warning, pink, purple, yellow, error]
+    }
 }

--- a/Oak/Oak/OakApp.swift
+++ b/Oak/Oak/OakApp.swift
@@ -14,8 +14,12 @@ internal struct OakApp: App {
                 keyboardShortcutService: appDelegate.keyboardShortcutService,
                 progressManager: appDelegate.notchWindowController?.viewModel.progressManager
             )
-            .frame(minWidth: 520, idealWidth: 560, minHeight: 520, idealHeight: 620)
+            .frame(
+                minWidth: SettingsWindowLayout.minimumWidth,
+                idealWidth: SettingsWindowLayout.idealWidth
+            )
         }
+        .windowResizability(.contentSize)
     }
 }
 

--- a/Oak/Oak/OakApp.swift
+++ b/Oak/Oak/OakApp.swift
@@ -14,7 +14,7 @@ internal struct OakApp: App {
                 keyboardShortcutService: appDelegate.keyboardShortcutService,
                 progressManager: appDelegate.notchWindowController?.viewModel.progressManager
             )
-            .frame(width: 420)
+            .frame(minWidth: 520, idealWidth: 560, minHeight: 520, idealHeight: 620)
         }
     }
 }

--- a/Oak/Oak/OakApp.swift
+++ b/Oak/Oak/OakApp.swift
@@ -15,7 +15,6 @@ internal struct OakApp: App {
                 progressManager: appDelegate.notchWindowController?.viewModel.progressManager
             )
             .frame(width: 420)
-            .padding(8)
         }
     }
 }

--- a/Oak/Oak/Services/PresetSettingsStore.swift
+++ b/Oak/Oak/Services/PresetSettingsStore.swift
@@ -22,7 +22,7 @@ internal final class PresetSettingsStore: ObservableObject {
     @Published private(set) var alwaysOnTop: Bool
     @Published private(set) var showBelowNotch: Bool
     @Published private(set) var autoStartNextInterval: Bool
-    @Published private(set) var theme: AppTheme
+    @Published internal private(set) var theme: AppTheme
 
     private let userDefaults: UserDefaults
 
@@ -221,7 +221,7 @@ internal final class PresetSettingsStore: ObservableObject {
         BehaviorConfig.saveAutoStartNext(value, to: userDefaults)
     }
 
-    func setTheme(_ value: AppTheme) {
+    internal func setTheme(_ value: AppTheme) {
         guard theme != value else { return }
         theme = value
         ThemeConfig.save(value, to: userDefaults)

--- a/Oak/Oak/Services/PresetSettingsStore.swift
+++ b/Oak/Oak/Services/PresetSettingsStore.swift
@@ -22,6 +22,7 @@ internal final class PresetSettingsStore: ObservableObject {
     @Published private(set) var alwaysOnTop: Bool
     @Published private(set) var showBelowNotch: Bool
     @Published private(set) var autoStartNextInterval: Bool
+    @Published private(set) var theme: AppTheme
 
     private let userDefaults: UserDefaults
 
@@ -42,6 +43,7 @@ internal final class PresetSettingsStore: ObservableObject {
         SessionDurationConfig.registerDefaults(in: userDefaults)
         DisplayConfig.registerDefaults(in: userDefaults)
         BehaviorConfig.registerDefaults(in: userDefaults)
+        ThemeConfig.registerDefaults(in: userDefaults)
 
         let duration = SessionDurationConfig.read(from: userDefaults)
         shortWorkMinutes = duration.shortWork
@@ -64,6 +66,7 @@ internal final class PresetSettingsStore: ObservableObject {
         playSoundOnSessionCompletion = behavior.playSoundOnSession
         playSoundOnBreakCompletion = behavior.playSoundOnBreak
         autoStartNextInterval = behavior.autoStartNext
+        theme = ThemeConfig.read(from: userDefaults)
 
         ensureDisplayIDsInitialized()
     }
@@ -218,6 +221,12 @@ internal final class PresetSettingsStore: ObservableObject {
         BehaviorConfig.saveAutoStartNext(value, to: userDefaults)
     }
 
+    func setTheme(_ value: AppTheme) {
+        guard theme != value else { return }
+        theme = value
+        ThemeConfig.save(value, to: userDefaults)
+    }
+
     // MARK: - Reset
 
     func resetToDefault() {
@@ -235,6 +244,7 @@ internal final class PresetSettingsStore: ObservableObject {
         setAlwaysOnTop(true)
         setShowBelowNotch(false)
         setAutoStartNextInterval(false)
+        setTheme(.oak)
     }
 
     // MARK: - Private helpers

--- a/Oak/Oak/Services/ThemeConfig.swift
+++ b/Oak/Oak/Services/ThemeConfig.swift
@@ -1,0 +1,22 @@
+import Foundation
+
+internal enum ThemeConfig {
+    private static let themeKey = "appearance.theme"
+
+    static func registerDefaults(in userDefaults: UserDefaults) {
+        userDefaults.register(defaults: [themeKey: AppTheme.oak.rawValue])
+    }
+
+    static func read(from userDefaults: UserDefaults) -> AppTheme {
+        guard let rawValue = userDefaults.string(forKey: themeKey),
+              let theme = AppTheme(rawValue: rawValue)
+        else {
+            return .oak
+        }
+        return theme
+    }
+
+    static func save(_ theme: AppTheme, to userDefaults: UserDefaults) {
+        userDefaults.set(theme.rawValue, forKey: themeKey)
+    }
+}

--- a/Oak/Oak/Services/ThemeConfig.swift
+++ b/Oak/Oak/Services/ThemeConfig.swift
@@ -3,11 +3,11 @@ import Foundation
 internal enum ThemeConfig {
     private static let themeKey = "appearance.theme"
 
-    static func registerDefaults(in userDefaults: UserDefaults) {
+    internal static func registerDefaults(in userDefaults: UserDefaults) {
         userDefaults.register(defaults: [themeKey: AppTheme.oak.rawValue])
     }
 
-    static func read(from userDefaults: UserDefaults) -> AppTheme {
+    internal static func read(from userDefaults: UserDefaults) -> AppTheme {
         guard let rawValue = userDefaults.string(forKey: themeKey),
               let theme = AppTheme(rawValue: rawValue)
         else {
@@ -16,7 +16,7 @@ internal enum ThemeConfig {
         return theme
     }
 
-    static func save(_ theme: AppTheme, to userDefaults: UserDefaults) {
+    internal static func save(_ theme: AppTheme, to userDefaults: UserDefaults) {
         userDefaults.set(theme.rawValue, forKey: themeKey)
     }
 }

--- a/Oak/Oak/Views/AudioMenuView.swift
+++ b/Oak/Oak/Views/AudioMenuView.swift
@@ -4,7 +4,10 @@ import UniformTypeIdentifiers
 internal struct AudioMenuView: View {
     @ObservedObject var audioManager: AudioManager
     @Binding var isImporting: Bool
+    var theme: AppTheme = .oak
     @State private var importError: String?
+
+    private var palette: ThemePalette { theme.palette }
 
     var body: some View {
         VStack(alignment: .leading, spacing: 14) {
@@ -23,7 +26,7 @@ internal struct AudioMenuView: View {
                         if audioManager.customAssets.isEmpty {
                             Text("Import audio to add a personal sound.")
                                 .font(.caption)
-                                .foregroundColor(.secondary)
+                                .foregroundColor(palette.secondaryForeground)
                                 .padding(.horizontal, 8)
                         } else {
                             ForEach(audioManager.customAssets) { asset in
@@ -47,27 +50,31 @@ internal struct AudioMenuView: View {
             if let error = importError ?? audioManager.audioError {
                 Text(error)
                     .font(.caption)
-                    .foregroundColor(.red)
+                    .foregroundColor(palette.error)
             }
 
             VStack(spacing: 6) {
                 HStack {
                     Image(systemName: "speaker.fill")
-                        .foregroundColor(.secondary)
+                        .foregroundColor(palette.secondaryForeground)
                         .font(.system(size: 12))
                     Slider(value: $audioManager.volume, in: 0 ... 1)
                         .frame(height: 20)
                     Image(systemName: "speaker.wave.3.fill")
-                        .foregroundColor(.secondary)
+                        .foregroundColor(palette.secondaryForeground)
                         .font(.system(size: 12))
                 }
                 .padding(.horizontal, 8)
                 Text("\(Int(audioManager.volume * 100))%")
                     .font(.caption)
-                    .foregroundColor(.secondary)
+                    .foregroundColor(palette.secondaryForeground)
             }
         }
         .padding()
+        .foregroundColor(palette.foreground)
+        .tint(palette.accent)
+        .background(palette.background)
+        .preferredColorScheme(.dark)
         .fileImporter(
             isPresented: $isImporting,
             allowedContentTypes: [.audio],
@@ -106,7 +113,7 @@ internal struct AudioMenuView: View {
         VStack(alignment: .leading, spacing: 6) {
             Text(title.uppercased())
                 .font(.caption2.weight(.semibold))
-                .foregroundColor(.secondary)
+                .foregroundColor(palette.secondaryForeground)
                 .padding(.horizontal, 8)
             content()
         }
@@ -137,13 +144,13 @@ internal struct AudioMenuView: View {
                         Spacer()
                         if isSelected && audioManager.isPlaying {
                             Image(systemName: "speaker.wave.2.fill")
-                                .foregroundColor(.blue)
+                                .foregroundColor(palette.accent)
                         }
                     }
-                    .foregroundColor(.primary)
+                    .foregroundColor(palette.foreground)
                     .padding(.horizontal, 8)
                     .padding(.vertical, 6)
-                    .background(isSelected ? Color.blue.opacity(0.1) : Color.clear)
+                    .background(isSelected ? palette.selectedBackground : Color.clear)
                     .cornerRadius(8)
                 }
             )
@@ -159,7 +166,7 @@ internal struct AudioMenuView: View {
                     },
                     label: {
                         Image(systemName: "trash")
-                            .foregroundColor(.secondary)
+                            .foregroundColor(palette.secondaryForeground)
                     }
                 )
                 .buttonStyle(.plain)

--- a/Oak/Oak/Views/AudioMenuView.swift
+++ b/Oak/Oak/Views/AudioMenuView.swift
@@ -7,7 +7,9 @@ internal struct AudioMenuView: View {
     internal let theme: AppTheme
     @State private var importError: String?
 
-    private var palette: ThemePalette { theme.palette }
+    private var palette: ThemePalette {
+        theme.palette
+    }
 
     var body: some View {
         VStack(alignment: .leading, spacing: 14) {
@@ -106,9 +108,9 @@ internal struct AudioMenuView: View {
         return error.localizedDescription
     }
 
-    private func soundSection<Content: View>(
+    private func soundSection(
         title: String,
-        @ViewBuilder content: () -> Content
+        @ViewBuilder content: () -> some View
     ) -> some View {
         VStack(alignment: .leading, spacing: 6) {
             Text(title.uppercased())

--- a/Oak/Oak/Views/AudioMenuView.swift
+++ b/Oak/Oak/Views/AudioMenuView.swift
@@ -4,7 +4,7 @@ import UniformTypeIdentifiers
 internal struct AudioMenuView: View {
     @ObservedObject var audioManager: AudioManager
     @Binding var isImporting: Bool
-    var theme: AppTheme = .oak
+    internal let theme: AppTheme
     @State private var importError: String?
 
     private var palette: ThemePalette { theme.palette }
@@ -74,7 +74,7 @@ internal struct AudioMenuView: View {
         .foregroundColor(palette.foreground)
         .tint(palette.accent)
         .background(palette.background)
-        .preferredColorScheme(.dark)
+        .preferredColorScheme(palette.colorScheme)
         .fileImporter(
             isPresented: $isImporting,
             allowedContentTypes: [.audio],

--- a/Oak/Oak/Views/ConfettiView.swift
+++ b/Oak/Oak/Views/ConfettiView.swift
@@ -4,11 +4,11 @@ internal struct ConfettiView: View {
     static let animationDuration: Double = 1.2
 
     let count: Int
-    let colors: [Color]
+    internal let colors: [Color]
     @State private var animating = false
     @State private var particles: [ConfettiParticle] = []
 
-    init(count: Int = 30, colors: [Color] = ConfettiPiece.colors) {
+    internal init(count: Int = 30, colors: [Color] = ConfettiPiece.colors) {
         self.count = count
         self.colors = colors
     }
@@ -43,7 +43,7 @@ internal struct ConfettiParticle: Identifiable {
     let rotation: Double
     let color: Color
 
-    static func generate(count: Int, colors: [Color] = ConfettiPiece.colors) -> [ConfettiParticle] {
+    internal static func generate(count: Int, colors: [Color] = ConfettiPiece.colors) -> [ConfettiParticle] {
         guard count > 0, !colors.isEmpty else { return [] }
         return (0 ..< count).map { index in
             ConfettiParticle(

--- a/Oak/Oak/Views/ConfettiView.swift
+++ b/Oak/Oak/Views/ConfettiView.swift
@@ -4,11 +4,13 @@ internal struct ConfettiView: View {
     static let animationDuration: Double = 1.2
 
     let count: Int
+    let colors: [Color]
     @State private var animating = false
     @State private var particles: [ConfettiParticle] = []
 
-    init(count: Int = 30) {
+    init(count: Int = 30, colors: [Color] = ConfettiPiece.colors) {
         self.count = count
+        self.colors = colors
     }
 
     var body: some View {
@@ -25,7 +27,7 @@ internal struct ConfettiView: View {
             }
         }
         .onAppear {
-            particles = ConfettiParticle.generate(count: count)
+            particles = ConfettiParticle.generate(count: count, colors: colors)
 
             withAnimation(.easeOut(duration: ConfettiView.animationDuration)) {
                 animating = true
@@ -41,15 +43,15 @@ internal struct ConfettiParticle: Identifiable {
     let rotation: Double
     let color: Color
 
-    static func generate(count: Int) -> [ConfettiParticle] {
-        guard count > 0 else { return [] }
+    static func generate(count: Int, colors: [Color] = ConfettiPiece.colors) -> [ConfettiParticle] {
+        guard count > 0, !colors.isEmpty else { return [] }
         return (0 ..< count).map { index in
             ConfettiParticle(
                 id: index,
                 targetX: CGFloat.random(in: -150 ... 150),
                 targetY: CGFloat.random(in: -100 ... 200),
                 rotation: Double.random(in: 0 ... 360),
-                color: ConfettiPiece.colors[index % ConfettiPiece.colors.count]
+                color: colors[index % colors.count]
             )
         }
     }

--- a/Oak/Oak/Views/DataSettingsView.swift
+++ b/Oak/Oak/Views/DataSettingsView.swift
@@ -5,7 +5,9 @@ internal struct DataSettingsView: View {
     internal let progressManager: ProgressManager?
     internal let theme: AppTheme
 
-    private var palette: ThemePalette { theme.palette }
+    private var palette: ThemePalette {
+        theme.palette
+    }
 
     internal var body: some View {
         VStack(alignment: .leading, spacing: 10) {

--- a/Oak/Oak/Views/DataSettingsView.swift
+++ b/Oak/Oak/Views/DataSettingsView.swift
@@ -1,0 +1,100 @@
+import AppKit
+import SwiftUI
+
+internal struct DataSettingsView: View {
+    internal let progressManager: ProgressManager?
+    internal let theme: AppTheme
+
+    private var palette: ThemePalette { theme.palette }
+
+    internal var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Text("Back up or restore your progress data.")
+                .font(.caption)
+                .foregroundColor(palette.secondaryForeground)
+
+            ViewThatFits(in: .horizontal) {
+                HStack(spacing: 8) {
+                    dataButtons
+                }
+
+                VStack(alignment: .leading, spacing: 8) {
+                    dataButtons
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var dataButtons: some View {
+        Button("Export JSON") {
+            exportJSON()
+        }
+        .buttonStyle(.bordered)
+        .disabled(progressManager == nil)
+
+        Button("Export CSV") {
+            exportCSV()
+        }
+        .buttonStyle(.bordered)
+        .disabled(progressManager == nil)
+
+        Button("Import Backup…") {
+            importData()
+        }
+        .buttonStyle(.borderedProminent)
+        .disabled(progressManager == nil)
+    }
+
+    private func exportJSON() {
+        guard let manager = progressManager,
+              let data = manager.exportJSON()
+        else { return }
+        let panel = NSSavePanel()
+        panel.nameFieldStringValue = "oak-progress-\(dateStamp()).json"
+        panel.allowedContentTypes = [.json]
+        panel.begin { response in
+            if response == .OK, let url = panel.url {
+                try? data.write(to: url)
+            }
+        }
+    }
+
+    private func exportCSV() {
+        guard let manager = progressManager else { return }
+        let csv = manager.exportCSV()
+        let panel = NSSavePanel()
+        panel.nameFieldStringValue = "oak-progress-\(dateStamp()).csv"
+        panel.allowedContentTypes = [.commaSeparatedText]
+        panel.begin { response in
+            if response == .OK, let url = panel.url {
+                try? csv.write(to: url, atomically: true, encoding: .utf8)
+            }
+        }
+    }
+
+    private func importData() {
+        guard let manager = progressManager else { return }
+        let panel = NSOpenPanel()
+        panel.allowedContentTypes = [.json]
+        panel.begin { response in
+            if response == .OK, let url = panel.url, let data = try? Data(contentsOf: url) {
+                let count = manager.importRecords(from: data)
+                if count > 0 {
+                    DispatchQueue.main.async {
+                        let alert = NSAlert()
+                        alert.messageText = "Import complete"
+                        alert.informativeText = "Imported \(count) day(s) of progress data."
+                        alert.runModal()
+                    }
+                }
+            }
+        }
+    }
+
+    private func dateStamp() -> String {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd"
+        return formatter.string(from: Date())
+    }
+}

--- a/Oak/Oak/Views/KeyboardSettingsView.swift
+++ b/Oak/Oak/Views/KeyboardSettingsView.swift
@@ -1,0 +1,99 @@
+import SwiftUI
+
+internal struct KeyboardSettingsView: View {
+    @ObservedObject internal var keyboardShortcutService: KeyboardShortcutService
+    internal let theme: AppTheme
+    @State private var localConfig: KeyboardShortcutConfig
+
+    private var palette: ThemePalette { theme.palette }
+
+    internal init(keyboardShortcutService: KeyboardShortcutService, theme: AppTheme) {
+        self.keyboardShortcutService = keyboardShortcutService
+        self.theme = theme
+        _localConfig = State(initialValue: keyboardShortcutService.currentConfig)
+    }
+
+    internal var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            toggleRow(
+                "Keyboard shortcuts",
+                description: "Use Space to start or pause and Escape to reset.",
+                isOn: Binding(
+                    get: { localConfig.enabled },
+                    set: { updateConfig(\.enabled, to: $0) }
+                )
+            )
+            .help("Works when Oak is active.")
+
+            if localConfig.enabled {
+                VStack(alignment: .leading, spacing: 6) {
+                    shortcutRow(
+                        action: .toggleSession,
+                        shortcut: localConfig.shortcuts[.toggleSession]
+                            ?? KeyboardShortcutAction.toggleSession.defaultKey
+                    )
+                    shortcutRow(
+                        action: .resetSession,
+                        shortcut: localConfig.shortcuts[.resetSession]
+                            ?? KeyboardShortcutAction.resetSession.defaultKey
+                    )
+                }
+                .padding(10)
+                .background(palette.controlBackground)
+                .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
+
+                toggleRow(
+                    "Global hotkeys",
+                    description: "Control Oak when another app is active. Requires Accessibility permission.",
+                    isOn: Binding(
+                        get: { localConfig.globalHotkeysEnabled },
+                        set: { updateConfig(\.globalHotkeysEnabled, to: $0) }
+                    )
+                )
+            }
+        }
+    }
+
+    private func toggleRow(_ title: String, description: String, isOn: Binding<Bool>) -> some View {
+        HStack(alignment: .center, spacing: 16) {
+            VStack(alignment: .leading, spacing: 2) {
+                Text(title)
+                Text(description)
+                    .font(.caption)
+                    .foregroundColor(palette.secondaryForeground)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+            .layoutPriority(1)
+
+            Spacer(minLength: 12)
+
+            Toggle(title, isOn: isOn)
+                .labelsHidden()
+                .toggleStyle(.switch)
+        }
+    }
+
+    private func shortcutRow(action: KeyboardShortcutAction, shortcut: KeyEquivalent) -> some View {
+        HStack(spacing: 10) {
+            Text(action.displayName)
+                .font(.callout)
+
+            Spacer()
+
+            Text(shortcut.displayString)
+                .font(.caption.monospaced())
+                .foregroundColor(palette.secondaryForeground)
+                .padding(.horizontal, 7)
+                .padding(.vertical, 3)
+                .background(palette.surface)
+                .clipShape(RoundedRectangle(cornerRadius: 5, style: .continuous))
+        }
+    }
+
+    private func updateConfig(_ keyPath: WritableKeyPath<KeyboardShortcutConfig, Bool>, to value: Bool) {
+        var updatedConfig = localConfig
+        updatedConfig[keyPath: keyPath] = value
+        localConfig = updatedConfig
+        keyboardShortcutService.updateConfig(updatedConfig)
+    }
+}

--- a/Oak/Oak/Views/KeyboardSettingsView.swift
+++ b/Oak/Oak/Views/KeyboardSettingsView.swift
@@ -5,7 +5,9 @@ internal struct KeyboardSettingsView: View {
     internal let theme: AppTheme
     @State private var localConfig: KeyboardShortcutConfig
 
-    private var palette: ThemePalette { theme.palette }
+    private var palette: ThemePalette {
+        theme.palette
+    }
 
     internal init(keyboardShortcutService: KeyboardShortcutService, theme: AppTheme) {
         self.keyboardShortcutService = keyboardShortcutService

--- a/Oak/Oak/Views/NotchCompanionView+InsideNotch.swift
+++ b/Oak/Oak/Views/NotchCompanionView+InsideNotch.swift
@@ -41,14 +41,14 @@ extension NotchCompanionView {
                 HStack(spacing: 4) {
                     Text("\(viewModel.autoStartCountdown)")
                         .font(.system(size: 14, weight: .semibold, design: .monospaced))
-                        .foregroundColor(.blue.opacity(0.95))
+                        .foregroundColor(palette.accent)
                     Text("starting...")
                         .font(.system(size: 8, weight: .medium))
-                        .foregroundColor(.white.opacity(0.62))
+                        .foregroundColor(palette.secondaryForeground)
                 }
                 Text("Next: \(viewModel.currentSessionType)")
                     .font(.system(size: 8, weight: .medium))
-                    .foregroundColor(.white.opacity(0.52))
+                    .foregroundColor(palette.subtleForeground)
             }
             .accessibilityElement(children: .combine)
             .accessibilityLabel(
@@ -69,7 +69,7 @@ extension NotchCompanionView {
                     countdownDisplay(mode: displayMode, size: expandedRingSize, fontSize: 13)
                     Text(viewModel.currentSessionType)
                         .font(.system(size: 8, weight: .medium))
-                        .foregroundColor(.white.opacity(0.56))
+                        .foregroundColor(palette.subtleForeground)
                 }
                 .accessibilityElement(children: .combine)
                 .accessibilityLabel("Time remaining: \(viewModel.displayTime), \(viewModel.currentSessionType)")
@@ -85,10 +85,10 @@ extension NotchCompanionView {
                 action: { viewModel.startSession(using: presetSelection) },
                 label: {
                     Image(systemName: "play.fill")
-                        .foregroundColor(.white)
+                        .foregroundColor(palette.background)
                         .font(.system(size: 10, weight: .bold))
                         .frame(width: 18, height: 18)
-                        .background(Color.green.opacity(0.88))
+                        .background(palette.success)
                         .clipShape(Circle())
                 }
             )
@@ -102,10 +102,10 @@ extension NotchCompanionView {
                     action: { viewModel.pauseSession() },
                     label: {
                         Image(systemName: "pause.fill")
-                            .foregroundColor(.white)
+                            .foregroundColor(palette.background)
                             .font(.system(size: 9, weight: .bold))
                             .frame(width: 18, height: 18)
-                            .background(Color.orange.opacity(0.88))
+                            .background(palette.warning)
                             .clipShape(Circle())
                     }
                 )
@@ -117,10 +117,10 @@ extension NotchCompanionView {
                     action: { viewModel.resumeSession() },
                     label: {
                         Image(systemName: "play.fill")
-                            .foregroundColor(.white)
+                            .foregroundColor(palette.background)
                             .font(.system(size: 9, weight: .bold))
                             .frame(width: 18, height: 18)
-                            .background(Color.green.opacity(0.88))
+                            .background(palette.success)
                             .clipShape(Circle())
                     }
                 )
@@ -132,10 +132,10 @@ extension NotchCompanionView {
                     action: { viewModel.startNextSession() },
                     label: {
                         Image(systemName: "forward.fill")
-                            .foregroundColor(.white)
+                            .foregroundColor(palette.background)
                             .font(.system(size: 9, weight: .bold))
                             .frame(width: 18, height: 18)
-                            .background(Color.blue.opacity(0.88))
+                            .background(palette.accent)
                             .clipShape(Circle())
                     }
                 )
@@ -149,10 +149,10 @@ extension NotchCompanionView {
                 action: { viewModel.resetSession() },
                 label: {
                     Image(systemName: "stop.fill")
-                        .foregroundColor(.white)
+                        .foregroundColor(palette.background)
                         .font(.system(size: 9, weight: .bold))
                         .frame(width: 18, height: 18)
-                        .background(Color.red.opacity(0.88))
+                        .background(palette.error)
                         .clipShape(Circle())
                 }
             )
@@ -172,10 +172,10 @@ extension NotchCompanionView {
             HStack(spacing: 4) {
                 Text("\(viewModel.autoStartCountdown)")
                     .font(.system(size: 13, weight: .semibold, design: .monospaced))
-                    .foregroundColor(.blue.opacity(0.95))
+                    .foregroundColor(palette.accent)
                 Text("starting...")
                     .font(.system(size: 8, weight: .medium))
-                    .foregroundColor(.white.opacity(0.52))
+                    .foregroundColor(palette.subtleForeground)
             }
             .accessibilityLabel("Auto-starting in \(viewModel.autoStartCountdown) seconds")
             .accessibilityIdentifier("autoStartCountdown")
@@ -198,10 +198,10 @@ extension NotchCompanionView {
                 action: { viewModel.startSession(using: presetSelection) },
                 label: {
                     Image(systemName: "play.fill")
-                        .foregroundColor(.white)
+                        .foregroundColor(palette.background)
                         .font(.system(size: 9, weight: .bold))
                         .frame(width: 16, height: 16)
-                        .background(Circle().fill(Color.green.opacity(0.85)))
+                        .background(Circle().fill(palette.success))
                 }
             )
             .buttonStyle(.plain)
@@ -213,10 +213,10 @@ extension NotchCompanionView {
                 action: { viewModel.startNextSession() },
                 label: {
                     Image(systemName: "forward.fill")
-                        .foregroundColor(.white)
+                        .foregroundColor(palette.background)
                         .font(.system(size: 9, weight: .bold))
                         .frame(width: 16, height: 16)
-                        .background(Circle().fill(Color.blue.opacity(0.88)))
+                        .background(Circle().fill(palette.accent))
                 }
             )
             .buttonStyle(.plain)
@@ -229,10 +229,10 @@ extension NotchCompanionView {
                 action: { viewModel.pauseSession() },
                 label: {
                     Image(systemName: "pause.fill")
-                        .foregroundColor(.white)
+                        .foregroundColor(palette.background)
                         .font(.system(size: 9, weight: .bold))
                         .frame(width: 16, height: 16)
-                        .background(Circle().fill(Color.orange.opacity(0.88)))
+                        .background(Circle().fill(palette.warning))
                 }
             )
             .buttonStyle(.plain)
@@ -244,10 +244,10 @@ extension NotchCompanionView {
                 action: { viewModel.resumeSession() },
                 label: {
                     Image(systemName: "play.fill")
-                        .foregroundColor(.white)
+                        .foregroundColor(palette.background)
                         .font(.system(size: 9, weight: .bold))
                         .frame(width: 16, height: 16)
-                        .background(Circle().fill(Color.green.opacity(0.88)))
+                        .background(Circle().fill(palette.success))
                 }
             )
             .buttonStyle(.plain)

--- a/Oak/Oak/Views/NotchCompanionView+StandardViews.swift
+++ b/Oak/Oak/Views/NotchCompanionView+StandardViews.swift
@@ -11,10 +11,10 @@ extension NotchCompanionView {
                     action: { viewModel.startSession(using: presetSelection) },
                     label: {
                         Image(systemName: "play.fill")
-                            .foregroundColor(.white)
+                            .foregroundColor(palette.background)
                             .font(.system(size: 9, weight: .bold))
                             .frame(width: 16, height: 16)
-                            .background(Circle().fill(Color.green.opacity(0.85)))
+                            .background(Circle().fill(palette.success))
                     }
                 )
                 .buttonStyle(.plain)
@@ -26,10 +26,10 @@ extension NotchCompanionView {
                     HStack(spacing: 4) {
                         Text("\(viewModel.autoStartCountdown)")
                             .font(.system(size: 13, weight: .semibold, design: .monospaced))
-                            .foregroundColor(.blue.opacity(0.95))
+                            .foregroundColor(palette.accent)
                         Text("starting...")
                             .font(.system(size: 8, weight: .medium))
-                            .foregroundColor(.white.opacity(0.52))
+                            .foregroundColor(palette.subtleForeground)
                     }
                     .accessibilityElement(children: .combine)
                     .accessibilityLabel("Auto-starting in \(viewModel.autoStartCountdown) seconds")
@@ -45,10 +45,10 @@ extension NotchCompanionView {
                     action: { viewModel.startNextSession() },
                     label: {
                         Image(systemName: "forward.fill")
-                            .foregroundColor(.white)
+                            .foregroundColor(palette.background)
                             .font(.system(size: 9, weight: .bold))
                             .frame(width: 16, height: 16)
-                            .background(Circle().fill(Color.blue.opacity(0.88)))
+                            .background(Circle().fill(palette.accent))
                     }
                 )
                 .buttonStyle(.plain)
@@ -78,15 +78,15 @@ extension NotchCompanionView {
                     CircularProgressRing(
                         progress: viewModel.progressPercentage,
                         lineWidth: 2.5,
-                        ringColor: viewModel.isPaused ? .orange : .white,
-                        backgroundColor: .white.opacity(0.2)
+                        ringColor: viewModel.isPaused ? palette.warning : palette.foreground,
+                        backgroundColor: palette.foreground.opacity(0.2)
                     )
                     .frame(width: size, height: size)
                     if showSessionType {
                         let sessionType = viewModel.currentSessionType
                         Text(sessionType == "Long Break" ? "Long\nBreak" : sessionType)
                             .font(.system(size: fontSize * 0.5, weight: .semibold))
-                            .foregroundColor(.white.opacity(0.9))
+                            .foregroundColor(palette.foreground)
                             .lineLimit(2)
                             .minimumScaleFactor(0.65)
                             .multilineTextAlignment(.center)
@@ -101,8 +101,8 @@ extension NotchCompanionView {
                     .font(.system(size: fontSize, weight: .semibold, design: .monospaced))
                     .foregroundColor(
                         viewModel.isPaused
-                            ? Color.orange.opacity(0.95)
-                            : Color.white.opacity(0.95)
+                            ? palette.warning
+                            : palette.foreground
                     )
                     .accessibilityLabel("Time remaining: \(viewModel.displayTime)")
                     .accessibilityValue(viewModel.isPaused ? "Paused" : "Running")
@@ -117,10 +117,10 @@ extension NotchCompanionView {
                 action: { viewModel.startSession(using: presetSelection) },
                 label: {
                     Image(systemName: "play.fill")
-                        .foregroundColor(.white)
+                        .foregroundColor(palette.background)
                         .font(.system(size: 10, weight: .bold))
                         .frame(width: controlSize, height: controlSize)
-                        .background(Color.green.opacity(0.88))
+                        .background(palette.success)
                         .clipShape(Circle())
                 }
             )
@@ -147,7 +147,7 @@ extension NotchCompanionView {
                         countdownDisplay(mode: displayMode, size: expandedRingSize, fontSize: 14)
                         Text(viewModel.currentSessionType)
                             .font(.system(size: 8, weight: .medium))
-                            .foregroundColor(.white.opacity(0.52))
+                            .foregroundColor(palette.subtleForeground)
                     }
                     .accessibilityElement(children: .combine)
                     .accessibilityLabel("Time remaining: \(viewModel.displayTime), \(viewModel.currentSessionType)")
@@ -159,14 +159,14 @@ extension NotchCompanionView {
                         HStack(spacing: 4) {
                             Text("\(viewModel.autoStartCountdown)")
                                 .font(.system(size: 14, weight: .semibold, design: .monospaced))
-                                .foregroundColor(.blue.opacity(0.95))
+                                .foregroundColor(palette.accent)
                             Text("starting...")
                                 .font(.system(size: 8, weight: .medium))
-                                .foregroundColor(.white.opacity(0.62))
+                                .foregroundColor(palette.secondaryForeground)
                         }
                         Text("Next: \(viewModel.currentSessionType)")
                             .font(.system(size: 8, weight: .medium))
-                            .foregroundColor(.white.opacity(0.52))
+                            .foregroundColor(palette.subtleForeground)
                     }
                     .accessibilityElement(children: .combine)
                     .accessibilityLabel(
@@ -186,7 +186,7 @@ extension NotchCompanionView {
                             countdownDisplay(mode: displayMode, size: expandedRingSize, fontSize: 14)
                             Text(viewModel.currentSessionType)
                                 .font(.system(size: 8, weight: .medium))
-                                .foregroundColor(.white.opacity(0.52))
+                                .foregroundColor(palette.subtleForeground)
                         }
                         .accessibilityElement(children: .combine)
                         .accessibilityLabel("Time remaining: \(viewModel.displayTime), \(viewModel.currentSessionType)")
@@ -206,7 +206,7 @@ extension NotchCompanionView {
                         countdownDisplay(mode: displayMode, size: expandedRingSize, fontSize: 14)
                         Text(viewModel.currentSessionType)
                             .font(.system(size: 8, weight: .medium))
-                            .foregroundColor(.white.opacity(0.52))
+                            .foregroundColor(palette.subtleForeground)
                     }
                     .accessibilityElement(children: .combine)
                     .accessibilityLabel("Time remaining: \(viewModel.displayTime), \(viewModel.currentSessionType)")
@@ -219,10 +219,10 @@ extension NotchCompanionView {
                     action: { viewModel.pauseSession() },
                     label: {
                         Image(systemName: "pause.fill")
-                            .foregroundColor(.white)
+                            .foregroundColor(palette.background)
                             .font(.system(size: 9, weight: .bold))
                             .frame(width: controlSize, height: controlSize)
-                            .background(Color.orange.opacity(0.88))
+                            .background(palette.warning)
                             .clipShape(Circle())
                     }
                 )
@@ -234,10 +234,10 @@ extension NotchCompanionView {
                     action: { viewModel.resumeSession() },
                     label: {
                         Image(systemName: "play.fill")
-                            .foregroundColor(.white)
+                            .foregroundColor(palette.background)
                             .font(.system(size: 9, weight: .bold))
                             .frame(width: controlSize, height: controlSize)
-                            .background(Color.green.opacity(0.88))
+                            .background(palette.success)
                             .clipShape(Circle())
                     }
                 )
@@ -249,10 +249,10 @@ extension NotchCompanionView {
                     action: { viewModel.startNextSession() },
                     label: {
                         Image(systemName: "forward.fill")
-                            .foregroundColor(.white)
+                            .foregroundColor(palette.background)
                             .font(.system(size: 9, weight: .bold))
                             .frame(width: controlSize, height: controlSize)
-                            .background(Color.blue.opacity(0.88))
+                            .background(palette.accent)
                             .clipShape(Circle())
                     }
                 )
@@ -265,10 +265,10 @@ extension NotchCompanionView {
                 action: { viewModel.resetSession() },
                 label: {
                     Image(systemName: "stop.fill")
-                        .foregroundColor(.white)
+                        .foregroundColor(palette.background)
                         .font(.system(size: 9, weight: .bold))
                         .frame(width: 18, height: 18)
-                        .background(Color.red.opacity(0.88))
+                        .background(palette.error)
                         .clipShape(Circle())
                 }
             )

--- a/Oak/Oak/Views/NotchCompanionView.swift
+++ b/Oak/Oak/Views/NotchCompanionView.swift
@@ -178,7 +178,9 @@ extension NotchCompanionView {
                         .frame(width: controlSize, height: controlSize)
 
                     Image(systemName: viewModel.audioManager.selectedSound.systemImageName)
-                        .foregroundColor(viewModel.audioManager.isPlaying ? palette.accent : palette.secondaryForeground)
+                        .foregroundColor(
+                            viewModel.audioManager.isPlaying ? palette.accent : palette.secondaryForeground
+                        )
                         .font(.system(size: 9))
                 }
             }

--- a/Oak/Oak/Views/NotchCompanionView.swift
+++ b/Oak/Oak/Views/NotchCompanionView.swift
@@ -48,7 +48,9 @@ internal struct NotchCompanionView: View {
         NotchVisualStyle.make(theme: viewModel.presetSettings.theme, isInsideNotch: isInsideNotch)
     }
 
-    internal var palette: ThemePalette { viewModel.presetSettings.theme.palette }
+    internal var palette: ThemePalette {
+        viewModel.presetSettings.theme.palette
+    }
 
     private var isInsideNotch: Bool {
         let settings = viewModel.presetSettings
@@ -195,10 +197,10 @@ extension NotchCompanionView {
                 isImporting: $isAudioImporterPresented,
                 theme: viewModel.presetSettings.theme
             )
-                .frame(width: 280)
-                .dismissOnClickOutside(isDismissalSuppressed: $isAudioImporterPresented) { [self] in
-                    showAudioMenu = false
-                }
+            .frame(width: 280)
+            .dismissOnClickOutside(isDismissalSuppressed: $isAudioImporterPresented) { [self] in
+                showAudioMenu = false
+            }
         }
     }
 

--- a/Oak/Oak/Views/NotchCompanionView.swift
+++ b/Oak/Oak/Views/NotchCompanionView.swift
@@ -48,7 +48,7 @@ internal struct NotchCompanionView: View {
         NotchVisualStyle.make(theme: viewModel.presetSettings.theme, isInsideNotch: isInsideNotch)
     }
 
-    var palette: ThemePalette { viewModel.presetSettings.theme.palette }
+    internal var palette: ThemePalette { viewModel.presetSettings.theme.palette }
 
     private var isInsideNotch: Bool {
         let settings = viewModel.presetSettings
@@ -109,7 +109,7 @@ internal struct NotchCompanionView: View {
         }
         .frame(height: NotchLayout.height)
         .tint(palette.accent)
-        .preferredColorScheme(.dark)
+        .preferredColorScheme(palette.colorScheme)
         .contentShape(Rectangle())
         .onChange(of: isExpanded) { expanded in
             notifyExpansionChanged(expanded)

--- a/Oak/Oak/Views/NotchCompanionView.swift
+++ b/Oak/Oak/Views/NotchCompanionView.swift
@@ -45,8 +45,10 @@ internal struct NotchCompanionView: View {
     }
 
     var visualStyle: NotchVisualStyle {
-        NotchVisualStyle.make(isInsideNotch: isInsideNotch)
+        NotchVisualStyle.make(theme: viewModel.presetSettings.theme, isInsideNotch: isInsideNotch)
     }
+
+    var palette: ThemePalette { viewModel.presetSettings.theme.palette }
 
     private var isInsideNotch: Bool {
         let settings = viewModel.presetSettings
@@ -101,11 +103,13 @@ internal struct NotchCompanionView: View {
             .scaleEffect(animateCompletion ? 1.05 : 1.0)
             .animation(.spring(response: 0.3, dampingFraction: 0.7), value: animateCompletion)
             if showConfetti {
-                ConfettiView()
+                ConfettiView(colors: palette.confettiColors)
                     .allowsHitTesting(false)
             }
         }
         .frame(height: NotchLayout.height)
+        .tint(palette.accent)
+        .preferredColorScheme(.dark)
         .contentShape(Rectangle())
         .onChange(of: isExpanded) { expanded in
             notifyExpansionChanged(expanded)
@@ -151,7 +155,7 @@ extension NotchCompanionView {
                     Image(systemName: "chevron.up.chevron.down")
                         .font(.system(size: 6, weight: .semibold))
                 }
-                .foregroundColor(.white.opacity(0.68))
+                .foregroundColor(palette.secondaryForeground)
             }
         )
         .buttonStyle(.plain)
@@ -168,13 +172,13 @@ extension NotchCompanionView {
                     Circle()
                         .fill(
                             viewModel.audioManager.isPlaying
-                                ? Color.blue.opacity(isExpanded ? 0.25 : 0.34)
-                                : Color.white.opacity(visualStyle.neutralControlOpacity)
+                                ? palette.accent.opacity(isExpanded ? 0.25 : 0.34)
+                                : palette.foreground.opacity(visualStyle.neutralControlOpacity)
                         )
                         .frame(width: controlSize, height: controlSize)
 
                     Image(systemName: viewModel.audioManager.selectedSound.systemImageName)
-                        .foregroundColor(viewModel.audioManager.isPlaying ? .blue : .white.opacity(0.7))
+                        .foregroundColor(viewModel.audioManager.isPlaying ? palette.accent : palette.secondaryForeground)
                         .font(.system(size: 9))
                 }
             }
@@ -186,7 +190,8 @@ extension NotchCompanionView {
         .popover(isPresented: $showAudioMenu) {
             AudioMenuView(
                 audioManager: viewModel.audioManager,
-                isImporting: $isAudioImporterPresented
+                isImporting: $isAudioImporterPresented,
+                theme: viewModel.presetSettings.theme
             )
                 .frame(width: 280)
                 .dismissOnClickOutside(isDismissalSuppressed: $isAudioImporterPresented) { [self] in
@@ -203,18 +208,18 @@ extension NotchCompanionView {
                     Circle()
                         .fill(
                             viewModel.streakDays > 0
-                                ? Color.orange.opacity(isExpanded ? 0.24 : 0.34)
-                                : Color.white.opacity(visualStyle.neutralControlOpacity)
+                                ? palette.warning.opacity(isExpanded ? 0.24 : 0.34)
+                                : palette.foreground.opacity(visualStyle.neutralControlOpacity)
                         )
                         .frame(width: controlSize, height: controlSize)
 
                     if viewModel.streakDays > 0 {
                         Text("\(viewModel.streakDays)")
                             .font(.system(size: 8, weight: .semibold))
-                            .foregroundColor(.orange)
+                            .foregroundColor(palette.warning)
                     } else {
                         Image(systemName: "chart.bar.fill")
-                            .foregroundColor(.white.opacity(0.7))
+                            .foregroundColor(palette.secondaryForeground)
                             .font(.system(size: 9))
                     }
                 }
@@ -243,11 +248,11 @@ extension NotchCompanionView {
             label: {
                 ZStack {
                     Circle()
-                        .fill(Color.white.opacity(visualStyle.neutralControlOpacity))
+                        .fill(palette.foreground.opacity(visualStyle.neutralControlOpacity))
                         .frame(width: controlSize, height: controlSize)
 
                     Image(systemName: "gearshape.fill")
-                        .foregroundColor(.white.opacity(0.7))
+                        .foregroundColor(palette.secondaryForeground)
                         .font(.system(size: 9))
                 }
             }
@@ -286,11 +291,11 @@ extension NotchCompanionView {
             label: {
                 Image(systemName: isExpanded ? "chevron.compact.left" : "chevron.compact.right")
                     .font(.system(size: 12, weight: .semibold))
-                    .foregroundColor(.white.opacity(0.75))
+                    .foregroundColor(palette.secondaryForeground)
                     .frame(width: controlSize, height: controlSize)
                     .background(
                         Circle()
-                            .fill(Color.white.opacity(visualStyle.toggleControlOpacity))
+                            .fill(palette.foreground.opacity(visualStyle.toggleControlOpacity))
                     )
             }
         )
@@ -312,7 +317,7 @@ extension NotchCompanionView {
         .padding(2)
         .background(
             Capsule(style: .continuous)
-                .fill(Color.white.opacity(visualStyle.presetCapsuleOpacity))
+                .fill(palette.foreground.opacity(visualStyle.presetCapsuleOpacity))
         )
         .accessibilityElement(children: .contain)
         .accessibilityLabel("Preset selector")
@@ -327,11 +332,11 @@ extension NotchCompanionView {
             label: {
                 Text(presetName)
                     .font(.system(size: 10, weight: .semibold))
-                    .foregroundColor(isSelected ? .white : .white.opacity(0.62))
+                    .foregroundColor(isSelected ? palette.foreground : palette.secondaryForeground)
                     .frame(minWidth: 54, minHeight: 18)
                     .background(
                         Capsule(style: .continuous)
-                            .fill(isSelected ? Color.white.opacity(0.16) : Color.clear)
+                            .fill(isSelected ? palette.selectedBackground : Color.clear)
                     )
             }
         )

--- a/Oak/Oak/Views/NotchVisualStyle+Factory.swift
+++ b/Oak/Oak/Views/NotchVisualStyle+Factory.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
 internal extension NotchVisualStyle {
-    internal static func make(theme: AppTheme, isInsideNotch: Bool) -> NotchVisualStyle {
+    static func make(theme: AppTheme, isInsideNotch: Bool) -> NotchVisualStyle {
         let palette = theme.palette
         return NotchVisualStyle(
             isInsideNotchStyle: isInsideNotch,

--- a/Oak/Oak/Views/NotchVisualStyle+Factory.swift
+++ b/Oak/Oak/Views/NotchVisualStyle+Factory.swift
@@ -1,13 +1,13 @@
 import SwiftUI
 
 internal extension NotchVisualStyle {
-    static func make(theme: AppTheme, isInsideNotch: Bool) -> NotchVisualStyle {
+    internal static func make(theme: AppTheme, isInsideNotch: Bool) -> NotchVisualStyle {
         let palette = theme.palette
         return NotchVisualStyle(
             isInsideNotchStyle: isInsideNotch,
             backgroundColors: [
                 palette.background,
-                palette.surface.opacity(0.92)
+                palette.surface
             ],
             borderColor: .clear,
             borderWidth: 0,

--- a/Oak/Oak/Views/NotchVisualStyle+Factory.swift
+++ b/Oak/Oak/Views/NotchVisualStyle+Factory.swift
@@ -3,7 +3,7 @@ import SwiftUI
 internal extension NotchVisualStyle {
     static func make(theme: AppTheme, isInsideNotch: Bool) -> NotchVisualStyle {
         let palette = theme.palette
-        NotchVisualStyle(
+        return NotchVisualStyle(
             isInsideNotchStyle: isInsideNotch,
             backgroundColors: [
                 palette.background,

--- a/Oak/Oak/Views/NotchVisualStyle+Factory.swift
+++ b/Oak/Oak/Views/NotchVisualStyle+Factory.swift
@@ -1,18 +1,19 @@
 import SwiftUI
 
 internal extension NotchVisualStyle {
-    static func make(isInsideNotch: Bool) -> NotchVisualStyle {
+    static func make(theme: AppTheme, isInsideNotch: Bool) -> NotchVisualStyle {
+        let palette = theme.palette
         NotchVisualStyle(
             isInsideNotchStyle: isInsideNotch,
             backgroundColors: [
-                Color.black.opacity(0.98),
-                Color(red: 0.01, green: 0.01, blue: 0.02).opacity(0.99)
+                palette.background,
+                palette.surface.opacity(0.92)
             ],
             borderColor: .clear,
             borderWidth: 0,
             shadowColor: .clear,
             shadowRadius: 0,
-            dividerColor: Color.white.opacity(0.26),
+            dividerColor: palette.divider,
             neutralControlOpacity: 0.17,
             toggleControlOpacity: 0.20,
             presetCapsuleOpacity: 0.18,

--- a/Oak/Oak/Views/NotificationSettingsView.swift
+++ b/Oak/Oak/Views/NotificationSettingsView.swift
@@ -1,57 +1,105 @@
 import SwiftUI
 
 internal struct NotificationSettingsView: View {
-    @ObservedObject var presetSettings: PresetSettingsStore
-    @ObservedObject var notificationService: NotificationService
+    @ObservedObject internal var presetSettings: PresetSettingsStore
+    @ObservedObject internal var notificationService: NotificationService
 
     private var palette: ThemePalette { presetSettings.theme.palette }
 
-    var body: some View {
-        VStack(alignment: .leading, spacing: 8) {
-            Text(notificationStatusText)
-                .font(.caption)
-                .foregroundColor(palette.secondaryForeground)
+    internal var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack(alignment: .top, spacing: 10) {
+                Image(systemName: notificationStatusImage)
+                    .foregroundColor(notificationService.isAuthorized ? palette.success : palette.warning)
+                    .frame(width: 18)
 
-            Toggle(
-                "Play completion sound",
+                Text(notificationStatusText)
+                    .font(.callout)
+                    .foregroundColor(palette.secondaryForeground)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+
+            notificationActions
+
+            Divider()
+
+            notificationToggle(
+                "Session completion sound",
+                description: "Play a sound when a focus session ends.",
                 isOn: Binding(
                     get: { presetSettings.playSoundOnSessionCompletion },
                     set: { presetSettings.setPlaySoundOnSessionCompletion($0) }
                 )
             )
-            .font(.caption)
 
-            Toggle(
-                "Play sound on break completion",
+            notificationToggle(
+                "Break completion sound",
+                description: "Play a sound when a break ends.",
                 isOn: Binding(
                     get: { presetSettings.playSoundOnBreakCompletion },
                     set: { presetSettings.setPlaySoundOnBreakCompletion($0) }
                 )
             )
-            .font(.caption)
             .disabled(!presetSettings.playSoundOnSessionCompletion)
+        }
+    }
 
+    @ViewBuilder
+    private var notificationActions: some View {
+        ViewThatFits(in: .horizontal) {
             HStack(spacing: 8) {
-                if notificationService.authorizationStatus == .notDetermined {
-                    Button("Allow Notifications") {
-                        Task {
-                            await notificationService.requestAuthorization()
-                        }
-                    }
-                } else if !notificationService.isAuthorized {
-                    Button("Open System Settings") {
-                        notificationService.openNotificationSettings()
-                    }
-                }
+                actionButtons
+            }
 
-                Button("Refresh Status") {
-                    Task {
-                        await notificationService.refreshAuthorizationStatus()
-                    }
+            VStack(alignment: .leading, spacing: 8) {
+                actionButtons
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var actionButtons: some View {
+        if notificationService.authorizationStatus == .notDetermined {
+            Button("Allow Notifications") {
+                Task {
+                    await notificationService.requestAuthorization()
                 }
             }
-            .buttonStyle(.link)
+            .buttonStyle(.borderedProminent)
+        } else if !notificationService.isAuthorized {
+            Button("Open System Settings") {
+                notificationService.openNotificationSettings()
+            }
+            .buttonStyle(.borderedProminent)
         }
+
+        Button("Refresh Status") {
+            Task {
+                await notificationService.refreshAuthorizationStatus()
+            }
+        }
+        .buttonStyle(.bordered)
+    }
+
+    private func notificationToggle(_ title: String, description: String, isOn: Binding<Bool>) -> some View {
+        HStack(alignment: .center, spacing: 16) {
+            VStack(alignment: .leading, spacing: 2) {
+                Text(title)
+                Text(description)
+                    .font(.caption)
+                    .foregroundColor(palette.secondaryForeground)
+            }
+
+            Spacer(minLength: 12)
+
+            Toggle(title, isOn: isOn)
+                .labelsHidden()
+                .toggleStyle(.switch)
+        }
+    }
+
+    private var notificationStatusImage: String {
+        notificationService.isAuthorized ? "checkmark.circle.fill" : "exclamationmark.circle.fill"
     }
 
     private var notificationStatusText: String {

--- a/Oak/Oak/Views/NotificationSettingsView.swift
+++ b/Oak/Oak/Views/NotificationSettingsView.swift
@@ -4,11 +4,13 @@ internal struct NotificationSettingsView: View {
     @ObservedObject var presetSettings: PresetSettingsStore
     @ObservedObject var notificationService: NotificationService
 
+    private var palette: ThemePalette { presetSettings.theme.palette }
+
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
             Text(notificationStatusText)
                 .font(.caption)
-                .foregroundColor(.secondary)
+                .foregroundColor(palette.secondaryForeground)
 
             Toggle(
                 "Play completion sound",

--- a/Oak/Oak/Views/NotificationSettingsView.swift
+++ b/Oak/Oak/Views/NotificationSettingsView.swift
@@ -4,7 +4,9 @@ internal struct NotificationSettingsView: View {
     @ObservedObject internal var presetSettings: PresetSettingsStore
     @ObservedObject internal var notificationService: NotificationService
 
-    private var palette: ThemePalette { presetSettings.theme.palette }
+    private var palette: ThemePalette {
+        presetSettings.theme.palette
+    }
 
     internal var body: some View {
         VStack(alignment: .leading, spacing: 12) {
@@ -44,7 +46,6 @@ internal struct NotificationSettingsView: View {
         }
     }
 
-    @ViewBuilder
     private var notificationActions: some View {
         ViewThatFits(in: .horizontal) {
             HStack(spacing: 8) {

--- a/Oak/Oak/Views/PresetEditorView.swift
+++ b/Oak/Oak/Views/PresetEditorView.swift
@@ -7,6 +7,8 @@ internal struct PresetEditorView: View {
     let title: String
     let preset: Preset
 
+    private var palette: ThemePalette { presetSettings.theme.palette }
+
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
             Text(title)
@@ -15,7 +17,7 @@ internal struct PresetEditorView: View {
             HStack(spacing: 8) {
                 Text("Focus")
                     .font(.caption)
-                    .foregroundColor(.secondary)
+                    .foregroundColor(palette.secondaryForeground)
                     .frame(width: 40, alignment: .leading)
 
                 Stepper(
@@ -30,7 +32,7 @@ internal struct PresetEditorView: View {
             HStack(spacing: 8) {
                 Text("Break")
                     .font(.caption)
-                    .foregroundColor(.secondary)
+                    .foregroundColor(palette.secondaryForeground)
                     .frame(width: 40, alignment: .leading)
 
                 Stepper(
@@ -45,7 +47,7 @@ internal struct PresetEditorView: View {
             HStack(spacing: 8) {
                 Text("Long")
                     .font(.caption)
-                    .foregroundColor(.secondary)
+                    .foregroundColor(palette.secondaryForeground)
                     .frame(width: 40, alignment: .leading)
 
                 Stepper(

--- a/Oak/Oak/Views/PresetEditorView.swift
+++ b/Oak/Oak/Views/PresetEditorView.swift
@@ -5,7 +5,9 @@ internal struct PresetEditorView: View {
     internal let title: String
     internal let preset: Preset
 
-    private var palette: ThemePalette { presetSettings.theme.palette }
+    private var palette: ThemePalette {
+        presetSettings.theme.palette
+    }
 
     internal var body: some View {
         VStack(alignment: .leading, spacing: 10) {

--- a/Oak/Oak/Views/PresetEditorView.swift
+++ b/Oak/Oak/Views/PresetEditorView.swift
@@ -1,63 +1,62 @@
 import SwiftUI
 
-/// Extracted from SettingsMenuView — renders stepper controls for focus, break, and long-break
-/// minutes within a single preset.
 internal struct PresetEditorView: View {
-    @ObservedObject var presetSettings: PresetSettingsStore
-    let title: String
-    let preset: Preset
+    @ObservedObject internal var presetSettings: PresetSettingsStore
+    internal let title: String
+    internal let preset: Preset
 
     private var palette: ThemePalette { presetSettings.theme.palette }
 
-    var body: some View {
-        VStack(alignment: .leading, spacing: 8) {
-            Text(title)
-                .font(.system(size: 11, weight: .medium))
+    internal var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Text("\(title) preset")
+                .font(.subheadline.weight(.semibold))
 
-            HStack(spacing: 8) {
-                Text("Focus")
-                    .font(.caption)
-                    .foregroundColor(palette.secondaryForeground)
-                    .frame(width: 40, alignment: .leading)
+            Divider()
 
-                Stepper(
-                    value: workMinutesBinding,
-                    in: PresetSettingsStore.minWorkMinutes ... PresetSettingsStore.maxWorkMinutes
-                ) {
-                    Text("\(presetSettings.workMinutes(for: preset)) min")
-                        .font(.caption)
-                }
+            durationRow(
+                "Focus",
+                minutes: presetSettings.workMinutes(for: preset),
+                binding: workMinutesBinding,
+                range: PresetSettingsStore.minWorkMinutes ... PresetSettingsStore.maxWorkMinutes
+            )
+            durationRow(
+                "Short break",
+                minutes: presetSettings.breakMinutes(for: preset),
+                binding: breakMinutesBinding,
+                range: PresetSettingsStore.minBreakMinutes ... PresetSettingsStore.maxBreakMinutes
+            )
+            durationRow(
+                "Long break",
+                minutes: presetSettings.longBreakMinutes(for: preset),
+                binding: longBreakMinutesBinding,
+                range: PresetSettingsStore.minBreakMinutes ... PresetSettingsStore.maxBreakMinutes
+            )
+        }
+        .padding(12)
+        .background(palette.controlBackground)
+        .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
+    }
+
+    private func durationRow(
+        _ label: String,
+        minutes: Int,
+        binding: Binding<Int>,
+        range: ClosedRange<Int>
+    ) -> some View {
+        HStack(spacing: 10) {
+            Text(label)
+                .font(.caption)
+                .foregroundColor(palette.secondaryForeground)
+
+            Spacer(minLength: 8)
+
+            Stepper(value: binding, in: range) {
+                Text("\(minutes) min")
+                    .font(.caption.monospacedDigit())
+                    .frame(minWidth: 48, alignment: .trailing)
             }
-
-            HStack(spacing: 8) {
-                Text("Break")
-                    .font(.caption)
-                    .foregroundColor(palette.secondaryForeground)
-                    .frame(width: 40, alignment: .leading)
-
-                Stepper(
-                    value: breakMinutesBinding,
-                    in: PresetSettingsStore.minBreakMinutes ... PresetSettingsStore.maxBreakMinutes
-                ) {
-                    Text("\(presetSettings.breakMinutes(for: preset)) min")
-                        .font(.caption)
-                }
-            }
-
-            HStack(spacing: 8) {
-                Text("Long")
-                    .font(.caption)
-                    .foregroundColor(palette.secondaryForeground)
-                    .frame(width: 40, alignment: .leading)
-
-                Stepper(
-                    value: longBreakMinutesBinding,
-                    in: PresetSettingsStore.minBreakMinutes ... PresetSettingsStore.maxBreakMinutes
-                ) {
-                    Text("\(presetSettings.longBreakMinutes(for: preset)) min")
-                        .font(.caption)
-                }
-            }
+            .fixedSize()
         }
     }
 

--- a/Oak/Oak/Views/ProgressMenuView.swift
+++ b/Oak/Oak/Views/ProgressMenuView.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
 internal struct ProgressMenuView: View {
-    @ObservedObject var viewModel: FocusSessionViewModel
+    @ObservedObject internal var viewModel: FocusSessionViewModel
     private var palette: ThemePalette {
         viewModel.presetSettings.theme.palette
     }
@@ -11,7 +11,7 @@ internal struct ProgressMenuView: View {
         return "\(viewModel.todayCompletedSessions) session\(suffix)"
     }
 
-    var body: some View {
+    internal var body: some View {
         VStack(spacing: 16) {
             Text("Today's Progress")
                 .font(.headline)

--- a/Oak/Oak/Views/ProgressMenuView.swift
+++ b/Oak/Oak/Views/ProgressMenuView.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 internal struct ProgressMenuView: View {
     @ObservedObject var viewModel: FocusSessionViewModel
+    private var palette: ThemePalette { viewModel.presetSettings.theme.palette }
     private var completedSessionsText: String {
         let suffix = viewModel.todayCompletedSessions == 1 ? "" : "s"
         return "\(viewModel.todayCompletedSessions) session\(suffix)"
@@ -16,7 +17,7 @@ internal struct ProgressMenuView: View {
             VStack(spacing: 12) {
                 HStack {
                     Image(systemName: "clock.fill")
-                        .foregroundColor(.blue)
+                        .foregroundColor(palette.accent)
                         .frame(width: 24)
                     VStack(alignment: .leading, spacing: 2) {
                         Text("\(viewModel.todayFocusMinutes) min")
@@ -24,14 +25,14 @@ internal struct ProgressMenuView: View {
                             .fontWeight(.semibold)
                         Text("Focus Time")
                             .font(.caption)
-                            .foregroundColor(.secondary)
+                            .foregroundColor(palette.secondaryForeground)
                     }
                     Spacer()
                 }
 
                 HStack {
                     Image(systemName: "checkmark.circle.fill")
-                        .foregroundColor(.green)
+                        .foregroundColor(palette.success)
                         .frame(width: 24)
                     VStack(alignment: .leading, spacing: 2) {
                         Text(completedSessionsText)
@@ -39,14 +40,14 @@ internal struct ProgressMenuView: View {
                             .fontWeight(.semibold)
                         Text("Completed")
                             .font(.caption)
-                            .foregroundColor(.secondary)
+                            .foregroundColor(palette.secondaryForeground)
                     }
                     Spacer()
                 }
 
                 HStack {
                     Image(systemName: "flame.fill")
-                        .foregroundColor(.orange)
+                        .foregroundColor(palette.warning)
                         .frame(width: 24)
                     VStack(alignment: .leading, spacing: 2) {
                         Text(
@@ -56,7 +57,7 @@ internal struct ProgressMenuView: View {
                         .fontWeight(.semibold)
                         Text("Streak")
                             .font(.caption)
-                            .foregroundColor(.secondary)
+                            .foregroundColor(palette.secondaryForeground)
                     }
                     Spacer()
                 }
@@ -71,7 +72,7 @@ internal struct ProgressMenuView: View {
                     Text(String(localized: "Timeline", comment: "Progress menu timeline section title"))
                         .font(.subheadline)
                         .fontWeight(.semibold)
-                        .foregroundColor(.secondary)
+                        .foregroundColor(palette.secondaryForeground)
                         .padding(.horizontal, 8)
 
                     ScrollView {
@@ -88,18 +89,18 @@ internal struct ProgressMenuView: View {
                                             .fontWeight(.medium)
                                         Text(timeRangeString(start: session.startTime, end: session.endTime))
                                             .font(.caption2)
-                                            .foregroundColor(.secondary)
+                                            .foregroundColor(palette.secondaryForeground)
                                     }
 
                                     Spacer()
 
                                     Text("\(session.durationMinutes)m")
                                         .font(.caption)
-                                        .foregroundColor(.secondary)
+                                        .foregroundColor(palette.secondaryForeground)
                                 }
                                 .padding(.horizontal, 8)
                                 .padding(.vertical, 4)
-                                .background(Color.secondary.opacity(0.1))
+                                .background(palette.controlBackground)
                                 .cornerRadius(8)
                             }
                         }
@@ -113,13 +114,17 @@ internal struct ProgressMenuView: View {
             }
         }
         .padding()
+        .foregroundColor(palette.foreground)
+        .tint(palette.accent)
+        .background(palette.background)
+        .preferredColorScheme(.dark)
     }
 
     private func colorForSessionType(_ type: SessionType) -> Color {
         switch type {
-        case .work: .blue
-        case .shortBreak: .green
-        case .longBreak: .orange
+        case .work: palette.accent
+        case .shortBreak: palette.success
+        case .longBreak: palette.warning
         }
     }
 

--- a/Oak/Oak/Views/ProgressMenuView.swift
+++ b/Oak/Oak/Views/ProgressMenuView.swift
@@ -117,7 +117,7 @@ internal struct ProgressMenuView: View {
         .foregroundColor(palette.foreground)
         .tint(palette.accent)
         .background(palette.background)
-        .preferredColorScheme(.dark)
+        .preferredColorScheme(palette.colorScheme)
     }
 
     private func colorForSessionType(_ type: SessionType) -> Color {

--- a/Oak/Oak/Views/ProgressMenuView.swift
+++ b/Oak/Oak/Views/ProgressMenuView.swift
@@ -2,7 +2,10 @@ import SwiftUI
 
 internal struct ProgressMenuView: View {
     @ObservedObject var viewModel: FocusSessionViewModel
-    private var palette: ThemePalette { viewModel.presetSettings.theme.palette }
+    private var palette: ThemePalette {
+        viewModel.presetSettings.theme.palette
+    }
+
     private var completedSessionsText: String {
         let suffix = viewModel.todayCompletedSessions == 1 ? "" : "s"
         return "\(viewModel.todayCompletedSessions) session\(suffix)"

--- a/Oak/Oak/Views/SettingsMenuView.swift
+++ b/Oak/Oak/Views/SettingsMenuView.swift
@@ -11,7 +11,9 @@ internal struct SettingsMenuView: View {
     @State private var selectedCountdownDisplayMode: CountdownDisplayMode
     @State private var selectedTab = SettingsTab.general
 
-    private var palette: ThemePalette { presetSettings.theme.palette }
+    private var palette: ThemePalette {
+        presetSettings.theme.palette
+    }
 
     internal init(
         presetSettings: PresetSettingsStore,
@@ -67,10 +69,10 @@ internal struct SettingsMenuView: View {
 }
 
 private extension SettingsMenuView {
-    func page<Content: View>(
+    func page(
         title: String,
         description: String,
-        @ViewBuilder content: () -> Content
+        @ViewBuilder content: () -> some View
     ) -> some View {
         ScrollView {
             VStack(alignment: .leading, spacing: 2) {
@@ -92,10 +94,10 @@ private extension SettingsMenuView {
         .background(palette.background)
     }
 
-    func settingsGroup<Content: View>(
+    func settingsGroup(
         title: String,
         systemImage: String,
-        @ViewBuilder content: () -> Content
+        @ViewBuilder content: () -> some View
     ) -> some View {
         VStack(alignment: .leading, spacing: 12) {
             Label(title, systemImage: systemImage)
@@ -117,10 +119,10 @@ private extension SettingsMenuView {
         }
     }
 
-    func settingRow<Control: View>(
+    func settingRow(
         _ title: String,
         description: String? = nil,
-        @ViewBuilder control: () -> Control
+        @ViewBuilder control: () -> some View
     ) -> some View {
         HStack(alignment: .center, spacing: 16) {
             VStack(alignment: .leading, spacing: 2) {

--- a/Oak/Oak/Views/SettingsMenuView.swift
+++ b/Oak/Oak/Views/SettingsMenuView.swift
@@ -2,6 +2,7 @@ import AppKit
 import SwiftUI
 
 internal struct SettingsMenuView: View {
+    @Environment(\.accessibilityReduceMotion) private var isReduceMotionEnabled
     @ObservedObject internal var presetSettings: PresetSettingsStore
     @ObservedObject internal var notificationService: NotificationService
     @ObservedObject internal var sparkleUpdater: SparkleUpdater
@@ -80,7 +81,7 @@ internal struct SettingsMenuView: View {
         .tint(palette.accent)
         .background(palette.background)
         .preferredColorScheme(palette.colorScheme)
-        .animation(.easeInOut(duration: 0.2), value: windowHeight)
+        .animation(isReduceMotionEnabled ? nil : .easeInOut(duration: 0.2), value: windowHeight)
         .onPreferenceChange(SettingsPageHeightPreferenceKey.self) { height in
             guard height > 0 else { return }
             pageContentHeight = ceil(height)

--- a/Oak/Oak/Views/SettingsMenuView.swift
+++ b/Oak/Oak/Views/SettingsMenuView.swift
@@ -124,24 +124,35 @@ private extension SettingsMenuView {
         description: String? = nil,
         @ViewBuilder control: () -> some View
     ) -> some View {
-        HStack(alignment: .center, spacing: 16) {
-            VStack(alignment: .leading, spacing: 2) {
-                Text(title)
-                    .font(.body)
+        ViewThatFits(in: .horizontal) {
+            HStack(alignment: .top, spacing: 16) {
+                settingLabel(title, description: description)
+                    .frame(minWidth: 180, maxWidth: .infinity, alignment: .leading)
 
-                if let description {
-                    Text(description)
-                        .font(.caption)
-                        .foregroundColor(palette.secondaryForeground)
-                        .fixedSize(horizontal: false, vertical: true)
-                }
+                control()
+                    .frame(width: 210, alignment: .trailing)
             }
-            .layoutPriority(1)
 
-            Spacer(minLength: 12)
+            VStack(alignment: .leading, spacing: 10) {
+                settingLabel(title, description: description)
 
-            control()
-                .fixedSize(horizontal: true, vertical: false)
+                control()
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            }
+        }
+    }
+
+    func settingLabel(_ title: String, description: String?) -> some View {
+        VStack(alignment: .leading, spacing: 2) {
+            Text(title)
+                .font(.body)
+
+            if let description {
+                Text(description)
+                    .font(.caption)
+                    .foregroundColor(palette.secondaryForeground)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
         }
     }
 

--- a/Oak/Oak/Views/SettingsMenuView.swift
+++ b/Oak/Oak/Views/SettingsMenuView.swift
@@ -64,8 +64,10 @@ internal struct SettingsMenuView: View {
             await notificationService.refreshAuthorizationStatus()
         }
     }
+}
 
-    private func page<Content: View>(
+private extension SettingsMenuView {
+    func page<Content: View>(
         title: String,
         description: String,
         @ViewBuilder content: () -> Content
@@ -90,7 +92,7 @@ internal struct SettingsMenuView: View {
         .background(palette.background)
     }
 
-    private func settingsGroup<Content: View>(
+    func settingsGroup<Content: View>(
         title: String,
         systemImage: String,
         @ViewBuilder content: () -> Content
@@ -115,7 +117,7 @@ internal struct SettingsMenuView: View {
         }
     }
 
-    private func settingRow<Control: View>(
+    func settingRow<Control: View>(
         _ title: String,
         description: String? = nil,
         @ViewBuilder control: () -> Control
@@ -141,7 +143,7 @@ internal struct SettingsMenuView: View {
         }
     }
 
-    private var generalPage: some View {
+    var generalPage: some View {
         page(title: "General", description: "Choose Oak's appearance and where the notch companion is shown.") {
             settingsGroup(title: "Appearance", systemImage: "paintpalette") {
                 themePicker
@@ -160,7 +162,7 @@ internal struct SettingsMenuView: View {
         }
     }
 
-    private var sessionsPage: some View {
+    var sessionsPage: some View {
         page(title: "Sessions", description: "Set session behavior and focus or break durations.") {
             settingsGroup(title: "Session Behavior", systemImage: "arrow.triangle.2.circlepath") {
                 autoStartNextIntervalToggle
@@ -188,7 +190,7 @@ internal struct SettingsMenuView: View {
         }
     }
 
-    private var notificationsPage: some View {
+    var notificationsPage: some View {
         page(title: "Notifications", description: "Manage session alerts and completion sounds.") {
             settingsGroup(title: "Alerts", systemImage: "bell.badge") {
                 NotificationSettingsView(
@@ -199,7 +201,7 @@ internal struct SettingsMenuView: View {
         }
     }
 
-    private var shortcutsPage: some View {
+    var shortcutsPage: some View {
         page(title: "Shortcuts", description: "Control sessions from the keyboard.") {
             settingsGroup(title: "Keyboard", systemImage: "keyboard") {
                 KeyboardSettingsView(
@@ -210,7 +212,7 @@ internal struct SettingsMenuView: View {
         }
     }
 
-    private var advancedPage: some View {
+    var advancedPage: some View {
         page(title: "Advanced", description: "Back up data, manage updates, and find project information.") {
             settingsGroup(title: "Data", systemImage: "externaldrive") {
                 DataSettingsView(progressManager: progressManager, theme: presetSettings.theme)
@@ -244,7 +246,7 @@ internal struct SettingsMenuView: View {
     }
 
     @ViewBuilder
-    private var applicationButtons: some View {
+    var applicationButtons: some View {
         Button("Reset to Defaults") {
             presetSettings.resetToDefault()
         }
@@ -257,7 +259,7 @@ internal struct SettingsMenuView: View {
         .help("Quit Oak")
     }
 
-    private func presetEditor(for preset: Preset) -> some View {
+    func presetEditor(for preset: Preset) -> some View {
         PresetEditorView(
             presetSettings: presetSettings,
             title: presetSettings.displayName(for: preset),
@@ -266,7 +268,7 @@ internal struct SettingsMenuView: View {
         .frame(maxWidth: .infinity, alignment: .leading)
     }
 
-    private var longBreakCycleEditor: some View {
+    var longBreakCycleEditor: some View {
         settingRow(
             "Long-break cycle",
             description: "Start a long break after this number of completed focus sessions."
@@ -280,7 +282,7 @@ internal struct SettingsMenuView: View {
         }
     }
 
-    private var themePicker: some View {
+    var themePicker: some View {
         settingRow("Theme", description: "Changes colors and the matching light or dark control appearance.") {
             Picker(
                 "Theme",
@@ -301,7 +303,7 @@ internal struct SettingsMenuView: View {
         .accessibilityIdentifier("themePicker")
     }
 
-    private var displayTargetPicker: some View {
+    var displayTargetPicker: some View {
         settingRow("Display", description: "The screen that shows the notch companion.") {
             Picker("Display", selection: displayTargetBinding) {
                 ForEach(DisplayTarget.allCases, id: \.rawValue) { target in
@@ -329,7 +331,7 @@ internal struct SettingsMenuView: View {
         }
     }
 
-    private var countdownDisplayModePicker: some View {
+    var countdownDisplayModePicker: some View {
         settingRow("Countdown style", description: "Show the remaining time as digits or a progress ring.") {
             Picker("Countdown style", selection: countdownDisplayModeBinding) {
                 ForEach(CountdownDisplayMode.allCases, id: \.rawValue) { mode in
@@ -347,7 +349,7 @@ internal struct SettingsMenuView: View {
         }
     }
 
-    private var alwaysOnTopToggle: some View {
+    var alwaysOnTopToggle: some View {
         settingRow("Always on top", description: "Keep the companion above other windows.") {
             Toggle(
                 "Always on top",
@@ -361,7 +363,7 @@ internal struct SettingsMenuView: View {
         }
     }
 
-    private var showBelowNotchToggle: some View {
+    var showBelowNotchToggle: some View {
         settingRow("Position", description: "Place the companion below the physical notch.") {
             Toggle(
                 "Show below notch",
@@ -375,7 +377,7 @@ internal struct SettingsMenuView: View {
         }
     }
 
-    private var autoStartNextIntervalToggle: some View {
+    var autoStartNextIntervalToggle: some View {
         settingRow(
             "Auto-start next interval",
             description: "Start the next focus or break interval after 10 seconds."
@@ -392,12 +394,10 @@ internal struct SettingsMenuView: View {
         }
     }
 
-    private var hasNotchedScreen: Bool {
+    var hasNotchedScreen: Bool {
         NSScreen.screens.contains { $0.hasNotch }
     }
-}
 
-private extension SettingsMenuView {
     var displayTargetBinding: Binding<DisplayTarget> {
         Binding(
             get: { selectedDisplayTarget },

--- a/Oak/Oak/Views/SettingsMenuView.swift
+++ b/Oak/Oak/Views/SettingsMenuView.swift
@@ -10,6 +10,8 @@ internal struct SettingsMenuView: View {
     @State private var selectedDisplayTarget: DisplayTarget
     @State private var selectedCountdownDisplayMode: CountdownDisplayMode
     @State private var selectedTab = SettingsTab.general
+    @State private var pageContentHeight = SettingsWindowLayout.initialPageHeight
+    @State private var navigationHeight = SettingsWindowLayout.initialNavigationHeight
 
     private var palette: ThemePalette {
         presetSettings.theme.palette
@@ -32,36 +34,61 @@ internal struct SettingsMenuView: View {
     }
 
     internal var body: some View {
-        TabView(selection: $selectedTab) {
-            generalPage
-                .tabItem { Label("General", systemImage: "gearshape") }
-                .tag(SettingsTab.general)
-                .accessibilityIdentifier("settingsTab_general")
+        let screenHeight = (NSApp.keyWindow?.screen ?? NSScreen.main)?.visibleFrame.height
+            ?? SettingsWindowLayout.fallbackScreenHeight
+        let windowHeight = SettingsWindowLayout.windowHeight(
+            pageContentHeight: pageContentHeight,
+            navigationHeight: navigationHeight,
+            screenHeight: screenHeight
+        )
+        let pageViewportHeight = SettingsWindowLayout.pageViewportHeight(
+            windowHeight: windowHeight,
+            navigationHeight: navigationHeight
+        )
 
-            sessionsPage
-                .tabItem { Label("Sessions", systemImage: "timer") }
-                .tag(SettingsTab.sessions)
-                .accessibilityIdentifier("settingsTab_sessions")
+        VStack(spacing: 0) {
+            SettingsTabNavigation(
+                selectedTab: $selectedTab,
+                theme: presetSettings.theme
+            )
+            .background {
+                GeometryReader { geometry in
+                    Color.clear.preference(
+                        key: SettingsNavigationHeightPreferenceKey.self,
+                        value: geometry.size.height
+                    )
+                }
+            }
 
-            notificationsPage
-                .tabItem { Label("Notifications", systemImage: "bell") }
-                .tag(SettingsTab.notifications)
-                .accessibilityIdentifier("settingsTab_notifications")
+            Divider()
 
-            shortcutsPage
-                .tabItem { Label("Shortcuts", systemImage: "keyboard") }
-                .tag(SettingsTab.shortcuts)
-                .accessibilityIdentifier("settingsTab_shortcuts")
-
-            advancedPage
-                .tabItem { Label("Advanced", systemImage: "slider.horizontal.3") }
-                .tag(SettingsTab.advanced)
-                .accessibilityIdentifier("settingsTab_advanced")
+            ScrollView {
+                activePage
+                    .background {
+                        GeometryReader { geometry in
+                            Color.clear.preference(
+                                key: SettingsPageHeightPreferenceKey.self,
+                                value: geometry.size.height
+                            )
+                        }
+                    }
+            }
+            .frame(height: pageViewportHeight)
         }
+        .frame(height: windowHeight)
         .foregroundColor(palette.foreground)
         .tint(palette.accent)
         .background(palette.background)
         .preferredColorScheme(palette.colorScheme)
+        .animation(.easeInOut(duration: 0.2), value: windowHeight)
+        .onPreferenceChange(SettingsPageHeightPreferenceKey.self) { height in
+            guard height > 0 else { return }
+            pageContentHeight = ceil(height)
+        }
+        .onPreferenceChange(SettingsNavigationHeightPreferenceKey.self) { height in
+            guard height > 0 else { return }
+            navigationHeight = ceil(height)
+        }
         .task {
             await notificationService.refreshAuthorizationStatus()
         }
@@ -69,28 +96,42 @@ internal struct SettingsMenuView: View {
 }
 
 private extension SettingsMenuView {
+    @ViewBuilder
+    var activePage: some View {
+        switch selectedTab {
+        case .general:
+            generalPage
+        case .sessions:
+            sessionsPage
+        case .notifications:
+            notificationsPage
+        case .shortcuts:
+            shortcutsPage
+        case .advanced:
+            advancedPage
+        }
+    }
+
     func page(
         title: String,
         description: String,
         @ViewBuilder content: () -> some View
     ) -> some View {
-        ScrollView {
-            VStack(alignment: .leading, spacing: 2) {
-                Text(title)
-                    .font(.title2.weight(.semibold))
-                Text(description)
-                    .font(.callout)
-                    .foregroundColor(palette.secondaryForeground)
-                    .fixedSize(horizontal: false, vertical: true)
+        VStack(alignment: .leading, spacing: 2) {
+            Text(title)
+                .font(.title2.weight(.semibold))
+            Text(description)
+                .font(.callout)
+                .foregroundColor(palette.secondaryForeground)
+                .fixedSize(horizontal: false, vertical: true)
 
-                VStack(alignment: .leading, spacing: 16) {
-                    content()
-                }
-                .padding(.top, 18)
+            VStack(alignment: .leading, spacing: 16) {
+                content()
             }
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .padding(20)
+            .padding(.top, 18)
         }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(20)
         .background(palette.background)
     }
 
@@ -241,7 +282,7 @@ private extension SettingsMenuView {
 
             settingsGroup(title: "About Oak", systemImage: "info.circle") {
                 settingRow("Version") {
-                    Text(currentVersion)
+                    Text(SettingsVersion.current)
                         .foregroundColor(palette.secondaryForeground)
                 }
 
@@ -437,28 +478,6 @@ private extension SettingsMenuView {
         )
     }
 
-    var currentVersion: String {
-        func getVersion(from bundle: Bundle) -> (String, String)? {
-            guard let shortVersion = bundle.infoDictionary?["CFBundleShortVersionString"] as? String,
-                  let buildVersion = bundle.infoDictionary?["CFBundleVersion"] as? String
-            else {
-                return nil
-            }
-            return (shortVersion, buildVersion)
-        }
-
-        let appBundle = Bundle.main
-        let fallbackBundle = Bundle(identifier: "com.productsway.oak.app") ?? Bundle(for: FocusSessionViewModel.self)
-
-        if let (shortVersion, buildVersion) = getVersion(from: appBundle) {
-            return "v\(shortVersion) (\(buildVersion))"
-        } else if let (shortVersion, buildVersion) = getVersion(from: fallbackBundle) {
-            return "v\(shortVersion) (\(buildVersion))"
-        }
-
-        return "v0.0.0 (0)"
-    }
-
     var validRangeDescription: String {
         let focusRange = "\(PresetSettingsStore.minWorkMinutes)-\(PresetSettingsStore.maxWorkMinutes)"
         let breakRange = "\(PresetSettingsStore.minBreakMinutes)-\(PresetSettingsStore.maxBreakMinutes)"
@@ -466,12 +485,4 @@ private extension SettingsMenuView {
             + "-\(PresetSettingsStore.maxRoundsBeforeLongBreak)"
         return "Valid range: Focus \(focusRange) min, Break \(breakRange) min, Long cycle \(cycleRange) sessions"
     }
-}
-
-private enum SettingsTab: Hashable {
-    case general
-    case sessions
-    case notifications
-    case shortcuts
-    case advanced
 }

--- a/Oak/Oak/Views/SettingsMenuView.swift
+++ b/Oak/Oak/Views/SettingsMenuView.swift
@@ -11,6 +11,8 @@ internal struct SettingsMenuView: View {
     @State private var selectedCountdownDisplayMode: CountdownDisplayMode
     @State private var localKeyboardConfig: KeyboardShortcutConfig
 
+    private var palette: ThemePalette { presetSettings.theme.palette }
+
     init(
         presetSettings: PresetSettingsStore,
         notificationService: NotificationService,
@@ -35,6 +37,7 @@ internal struct SettingsMenuView: View {
             Divider()
 
             section(title: "Display") {
+                themePicker
                 if NSScreen.screens.count > 1 {
                     displayTargetPicker
                 }
@@ -76,18 +79,18 @@ internal struct SettingsMenuView: View {
             }
 
             section(title: "Updates") {
-                UpdateSettingsView(sparkleUpdater: sparkleUpdater)
+                UpdateSettingsView(sparkleUpdater: sparkleUpdater, theme: presetSettings.theme)
             }
 
             section(title: "Support") {
-                SupportSectionView()
+                SupportSectionView(theme: presetSettings.theme)
             }
 
             Divider()
 
             Text(validRangeDescription)
                 .font(.caption2)
-                .foregroundColor(.secondary)
+                .foregroundColor(palette.secondaryForeground)
 
             HStack {
                 Button("Reset to defaults") {
@@ -99,10 +102,14 @@ internal struct SettingsMenuView: View {
 
                 Text(currentVersion)
                     .font(.caption)
-                    .foregroundColor(.secondary)
+                    .foregroundColor(palette.secondaryForeground)
             }
         }
         .padding(14)
+        .foregroundColor(palette.foreground)
+        .tint(palette.accent)
+        .background(palette.background)
+        .preferredColorScheme(.dark)
         .task {
             await notificationService.refreshAuthorizationStatus()
         }
@@ -115,7 +122,7 @@ internal struct SettingsMenuView: View {
                     .font(.headline)
                 Text("Focus presets, display, and notifications.")
                     .font(.caption)
-                    .foregroundColor(.secondary)
+                    .foregroundColor(palette.secondaryForeground)
             }
 
             Spacer()
@@ -132,7 +139,7 @@ internal struct SettingsMenuView: View {
         VStack(alignment: .leading, spacing: 8) {
             Text(title)
                 .font(.system(size: 12, weight: .semibold))
-                .foregroundColor(.primary)
+                .foregroundColor(palette.foreground)
             content()
         }
     }
@@ -145,6 +152,24 @@ internal struct SettingsMenuView: View {
             Text("Long break every \(presetSettings.roundsBeforeLongBreak) focus sessions")
                 .font(.caption)
         }
+    }
+
+    private var themePicker: some View {
+        Picker(
+            "Theme",
+            selection: Binding(
+                get: { presetSettings.theme },
+                set: { presetSettings.setTheme($0) }
+            )
+        ) {
+            ForEach(AppTheme.allCases) { theme in
+                Text(theme.displayName)
+                    .tag(theme)
+            }
+        }
+        .font(.caption)
+        .accessibilityHint("Changes Oak colors throughout the app")
+        .accessibilityIdentifier("themePicker")
     }
 
     private var displayTargetPicker: some View {
@@ -335,10 +360,10 @@ private extension SettingsMenuView {
         HStack(spacing: 8) {
             Text(shortcut.displayString)
                 .font(.caption.monospaced())
-                .foregroundColor(.secondary)
+                .foregroundColor(palette.secondaryForeground)
                 .padding(.horizontal, 4)
                 .padding(.vertical, 2)
-                .background(Color.secondary.opacity(0.1))
+                .background(palette.controlBackground)
                 .cornerRadius(4)
             Text(action.displayName)
                 .font(.caption)
@@ -352,7 +377,7 @@ private extension SettingsMenuView {
         VStack(alignment: .leading, spacing: 8) {
             Text("Back up or restore your progress data.")
                 .font(.caption)
-                .foregroundColor(.secondary)
+                .foregroundColor(palette.secondaryForeground)
 
             HStack(spacing: 8) {
                 Button("Export JSON") {

--- a/Oak/Oak/Views/SettingsMenuView.swift
+++ b/Oak/Oak/Views/SettingsMenuView.swift
@@ -109,7 +109,7 @@ internal struct SettingsMenuView: View {
         .foregroundColor(palette.foreground)
         .tint(palette.accent)
         .background(palette.background)
-        .preferredColorScheme(.dark)
+        .preferredColorScheme(palette.colorScheme)
         .task {
             await notificationService.refreshAuthorizationStatus()
         }

--- a/Oak/Oak/Views/SettingsMenuView.swift
+++ b/Oak/Oak/Views/SettingsMenuView.swift
@@ -2,18 +2,18 @@ import AppKit
 import SwiftUI
 
 internal struct SettingsMenuView: View {
-    @ObservedObject var presetSettings: PresetSettingsStore
-    @ObservedObject var notificationService: NotificationService
-    @ObservedObject var sparkleUpdater: SparkleUpdater
-    @ObservedObject var keyboardShortcutService: KeyboardShortcutService
-    var progressManager: ProgressManager?
+    @ObservedObject internal var presetSettings: PresetSettingsStore
+    @ObservedObject internal var notificationService: NotificationService
+    @ObservedObject internal var sparkleUpdater: SparkleUpdater
+    @ObservedObject internal var keyboardShortcutService: KeyboardShortcutService
+    internal var progressManager: ProgressManager?
     @State private var selectedDisplayTarget: DisplayTarget
     @State private var selectedCountdownDisplayMode: CountdownDisplayMode
-    @State private var localKeyboardConfig: KeyboardShortcutConfig
+    @State private var selectedTab = SettingsTab.general
 
     private var palette: ThemePalette { presetSettings.theme.palette }
 
-    init(
+    internal init(
         presetSettings: PresetSettingsStore,
         notificationService: NotificationService,
         sparkleUpdater: SparkleUpdater,
@@ -27,85 +27,35 @@ internal struct SettingsMenuView: View {
         self.progressManager = progressManager
         _selectedDisplayTarget = State(initialValue: presetSettings.displayTarget)
         _selectedCountdownDisplayMode = State(initialValue: presetSettings.countdownDisplayMode)
-        _localKeyboardConfig = State(initialValue: keyboardShortcutService.currentConfig)
     }
 
-    public var body: some View {
-        VStack(alignment: .leading, spacing: 12) {
-            headerRow
+    internal var body: some View {
+        TabView(selection: $selectedTab) {
+            generalPage
+                .tabItem { Label("General", systemImage: "gearshape") }
+                .tag(SettingsTab.general)
+                .accessibilityIdentifier("settingsTab_general")
 
-            Divider()
+            sessionsPage
+                .tabItem { Label("Sessions", systemImage: "timer") }
+                .tag(SettingsTab.sessions)
+                .accessibilityIdentifier("settingsTab_sessions")
 
-            section(title: "Display") {
-                themePicker
-                if NSScreen.screens.count > 1 {
-                    displayTargetPicker
-                }
-                countdownDisplayModePicker
-                alwaysOnTopToggle
-                if hasNotchedScreen {
-                    showBelowNotchToggle
-                }
-            }
+            notificationsPage
+                .tabItem { Label("Notifications", systemImage: "bell") }
+                .tag(SettingsTab.notifications)
+                .accessibilityIdentifier("settingsTab_notifications")
 
-            section(title: "Session Presets") {
-                autoStartNextIntervalToggle
-                longBreakCycleEditor
-                PresetEditorView(
-                    presetSettings: presetSettings,
-                    title: presetSettings.displayName(for: .short),
-                    preset: .short
-                )
-                PresetEditorView(
-                    presetSettings: presetSettings,
-                    title: presetSettings.displayName(for: .long),
-                    preset: .long
-                )
-            }
+            shortcutsPage
+                .tabItem { Label("Shortcuts", systemImage: "keyboard") }
+                .tag(SettingsTab.shortcuts)
+                .accessibilityIdentifier("settingsTab_shortcuts")
 
-            section(title: "Notifications") {
-                NotificationSettingsView(
-                    presetSettings: presetSettings,
-                    notificationService: notificationService
-                )
-            }
-
-            section(title: "Keyboard") {
-                keyboardSettingsSection
-            }
-
-            section(title: "Data") {
-                dataSection
-            }
-
-            section(title: "Updates") {
-                UpdateSettingsView(sparkleUpdater: sparkleUpdater, theme: presetSettings.theme)
-            }
-
-            section(title: "Support") {
-                SupportSectionView(theme: presetSettings.theme)
-            }
-
-            Divider()
-
-            Text(validRangeDescription)
-                .font(.caption2)
-                .foregroundColor(palette.secondaryForeground)
-
-            HStack {
-                Button("Reset to defaults") {
-                    presetSettings.resetToDefault()
-                }
-                .buttonStyle(.link)
-
-                Spacer()
-
-                Text(currentVersion)
-                    .font(.caption)
-                    .foregroundColor(palette.secondaryForeground)
-            }
+            advancedPage
+                .tabItem { Label("Advanced", systemImage: "slider.horizontal.3") }
+                .tag(SettingsTab.advanced)
+                .accessibilityIdentifier("settingsTab_advanced")
         }
-        .padding(14)
         .foregroundColor(palette.foreground)
         .tint(palette.accent)
         .background(palette.background)
@@ -115,135 +65,331 @@ internal struct SettingsMenuView: View {
         }
     }
 
-    private var headerRow: some View {
-        HStack(alignment: .firstTextBaseline) {
+    private func page<Content: View>(
+        title: String,
+        description: String,
+        @ViewBuilder content: () -> Content
+    ) -> some View {
+        ScrollView {
             VStack(alignment: .leading, spacing: 2) {
-                Text("Settings")
-                    .font(.headline)
-                Text("Focus presets, display, and notifications.")
-                    .font(.caption)
+                Text(title)
+                    .font(.title2.weight(.semibold))
+                Text(description)
+                    .font(.callout)
                     .foregroundColor(palette.secondaryForeground)
-            }
+                    .fixedSize(horizontal: false, vertical: true)
 
-            Spacer()
-
-            Button("Quit Oak") {
-                NSApplication.shared.terminate(nil)
+                VStack(alignment: .leading, spacing: 16) {
+                    content()
+                }
+                .padding(.top, 18)
             }
-            .buttonStyle(.link)
-            .help("Quit Oak")
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(20)
+        }
+        .background(palette.background)
+    }
+
+    private func settingsGroup<Content: View>(
+        title: String,
+        systemImage: String,
+        @ViewBuilder content: () -> Content
+    ) -> some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Label(title, systemImage: systemImage)
+                .font(.headline)
+
+            Divider()
+
+            VStack(alignment: .leading, spacing: 12) {
+                content()
+            }
+        }
+        .padding(14)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(palette.surface)
+        .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
+        .overlay {
+            RoundedRectangle(cornerRadius: 10, style: .continuous)
+                .stroke(palette.divider, lineWidth: 1)
         }
     }
 
-    private func section(title: String, @ViewBuilder content: () -> some View) -> some View {
-        VStack(alignment: .leading, spacing: 8) {
-            Text(title)
-                .font(.system(size: 12, weight: .semibold))
-                .foregroundColor(palette.foreground)
-            content()
+    private func settingRow<Control: View>(
+        _ title: String,
+        description: String? = nil,
+        @ViewBuilder control: () -> Control
+    ) -> some View {
+        HStack(alignment: .center, spacing: 16) {
+            VStack(alignment: .leading, spacing: 2) {
+                Text(title)
+                    .font(.body)
+
+                if let description {
+                    Text(description)
+                        .font(.caption)
+                        .foregroundColor(palette.secondaryForeground)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+            }
+            .layoutPriority(1)
+
+            Spacer(minLength: 12)
+
+            control()
+                .fixedSize(horizontal: true, vertical: false)
         }
+    }
+
+    private var generalPage: some View {
+        page(title: "General", description: "Choose Oak's appearance and where the notch companion is shown.") {
+            settingsGroup(title: "Appearance", systemImage: "paintpalette") {
+                themePicker
+            }
+
+            settingsGroup(title: "Display", systemImage: "display") {
+                if NSScreen.screens.count > 1 {
+                    displayTargetPicker
+                }
+                countdownDisplayModePicker
+                alwaysOnTopToggle
+                if hasNotchedScreen {
+                    showBelowNotchToggle
+                }
+            }
+        }
+    }
+
+    private var sessionsPage: some View {
+        page(title: "Sessions", description: "Set session behavior and focus or break durations.") {
+            settingsGroup(title: "Session Behavior", systemImage: "arrow.triangle.2.circlepath") {
+                autoStartNextIntervalToggle
+                longBreakCycleEditor
+            }
+
+            settingsGroup(title: "Presets", systemImage: "clock") {
+                ViewThatFits(in: .horizontal) {
+                    HStack(alignment: .top, spacing: 12) {
+                        presetEditor(for: .short)
+                        presetEditor(for: .long)
+                    }
+
+                    VStack(spacing: 12) {
+                        presetEditor(for: .short)
+                        presetEditor(for: .long)
+                    }
+                }
+
+                Text(validRangeDescription)
+                    .font(.caption)
+                    .foregroundColor(palette.secondaryForeground)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+    }
+
+    private var notificationsPage: some View {
+        page(title: "Notifications", description: "Manage session alerts and completion sounds.") {
+            settingsGroup(title: "Alerts", systemImage: "bell.badge") {
+                NotificationSettingsView(
+                    presetSettings: presetSettings,
+                    notificationService: notificationService
+                )
+            }
+        }
+    }
+
+    private var shortcutsPage: some View {
+        page(title: "Shortcuts", description: "Control sessions from the keyboard.") {
+            settingsGroup(title: "Keyboard", systemImage: "keyboard") {
+                KeyboardSettingsView(
+                    keyboardShortcutService: keyboardShortcutService,
+                    theme: presetSettings.theme
+                )
+            }
+        }
+    }
+
+    private var advancedPage: some View {
+        page(title: "Advanced", description: "Back up data, manage updates, and find project information.") {
+            settingsGroup(title: "Data", systemImage: "externaldrive") {
+                DataSettingsView(progressManager: progressManager, theme: presetSettings.theme)
+            }
+
+            settingsGroup(title: "Updates", systemImage: "arrow.down.circle") {
+                UpdateSettingsView(sparkleUpdater: sparkleUpdater, theme: presetSettings.theme)
+            }
+
+            settingsGroup(title: "Support", systemImage: "heart") {
+                SupportSectionView(theme: presetSettings.theme)
+            }
+
+            settingsGroup(title: "About Oak", systemImage: "info.circle") {
+                settingRow("Version") {
+                    Text(currentVersion)
+                        .foregroundColor(palette.secondaryForeground)
+                }
+
+                ViewThatFits(in: .horizontal) {
+                    HStack(spacing: 10) {
+                        applicationButtons
+                    }
+
+                    VStack(alignment: .leading, spacing: 8) {
+                        applicationButtons
+                    }
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var applicationButtons: some View {
+        Button("Reset to Defaults") {
+            presetSettings.resetToDefault()
+        }
+        .buttonStyle(.bordered)
+
+        Button("Quit Oak") {
+            NSApplication.shared.terminate(nil)
+        }
+        .buttonStyle(.bordered)
+        .help("Quit Oak")
+    }
+
+    private func presetEditor(for preset: Preset) -> some View {
+        PresetEditorView(
+            presetSettings: presetSettings,
+            title: presetSettings.displayName(for: preset),
+            preset: preset
+        )
+        .frame(maxWidth: .infinity, alignment: .leading)
     }
 
     private var longBreakCycleEditor: some View {
-        Stepper(
-            value: roundsBeforeLongBreakBinding,
-            in: PresetSettingsStore.minRoundsBeforeLongBreak ... PresetSettingsStore.maxRoundsBeforeLongBreak
+        settingRow(
+            "Long-break cycle",
+            description: "Start a long break after this number of completed focus sessions."
         ) {
-            Text("Long break every \(presetSettings.roundsBeforeLongBreak) focus sessions")
-                .font(.caption)
+            Stepper(
+                "\(presetSettings.roundsBeforeLongBreak) sessions",
+                value: roundsBeforeLongBreakBinding,
+                in: PresetSettingsStore.minRoundsBeforeLongBreak ... PresetSettingsStore.maxRoundsBeforeLongBreak
+            )
+            .frame(width: 130)
         }
     }
 
     private var themePicker: some View {
-        Picker(
-            "Theme",
-            selection: Binding(
-                get: { presetSettings.theme },
-                set: { presetSettings.setTheme($0) }
-            )
-        ) {
-            ForEach(AppTheme.allCases) { theme in
-                Text(theme.displayName)
-                    .tag(theme)
+        settingRow("Theme", description: "Changes colors and the matching light or dark control appearance.") {
+            Picker(
+                "Theme",
+                selection: Binding(
+                    get: { presetSettings.theme },
+                    set: { presetSettings.setTheme($0) }
+                )
+            ) {
+                ForEach(AppTheme.allCases) { theme in
+                    Text(theme.displayName)
+                        .tag(theme)
+                }
             }
+            .labelsHidden()
+            .frame(width: 210)
         }
-        .font(.caption)
         .accessibilityHint("Changes Oak colors throughout the app")
         .accessibilityIdentifier("themePicker")
     }
 
     private var displayTargetPicker: some View {
-        Picker("Display target", selection: displayTargetBinding) {
-            ForEach(DisplayTarget.allCases, id: \.rawValue) { target in
-                Text(
-                    NSScreen.displayName(
-                        for: target,
-                        preferredDisplayID: presetSettings.preferredDisplayID(for: target)
+        settingRow("Display", description: "The screen that shows the notch companion.") {
+            Picker("Display", selection: displayTargetBinding) {
+                ForEach(DisplayTarget.allCases, id: \.rawValue) { target in
+                    Text(
+                        NSScreen.displayName(
+                            for: target,
+                            preferredDisplayID: presetSettings.preferredDisplayID(for: target)
+                        )
                     )
-                )
-                .tag(target)
+                    .tag(target)
+                }
             }
-        }
-        .pickerStyle(.segmented)
-        .labelsHidden()
-        .onChange(of: selectedDisplayTarget) { newValue in
-            guard presetSettings.displayTarget != newValue else { return }
-            DispatchQueue.main.async {
-                presetSettings.setDisplayTarget(newValue)
+            .labelsHidden()
+            .frame(width: 210)
+            .onChange(of: selectedDisplayTarget) { newValue in
+                guard presetSettings.displayTarget != newValue else { return }
+                DispatchQueue.main.async {
+                    presetSettings.setDisplayTarget(newValue)
+                }
             }
-        }
-        .onChange(of: presetSettings.displayTarget) { newValue in
-            guard selectedDisplayTarget != newValue else { return }
-            selectedDisplayTarget = newValue
+            .onChange(of: presetSettings.displayTarget) { newValue in
+                guard selectedDisplayTarget != newValue else { return }
+                selectedDisplayTarget = newValue
+            }
         }
     }
 
     private var countdownDisplayModePicker: some View {
-        Picker("Countdown display mode", selection: countdownDisplayModeBinding) {
-            ForEach(CountdownDisplayMode.allCases, id: \.rawValue) { mode in
-                Text(mode.displayName)
-                    .tag(mode)
+        settingRow("Countdown style", description: "Show the remaining time as digits or a progress ring.") {
+            Picker("Countdown style", selection: countdownDisplayModeBinding) {
+                ForEach(CountdownDisplayMode.allCases, id: \.rawValue) { mode in
+                    Text(mode.displayName)
+                        .tag(mode)
+                }
             }
-        }
-        .pickerStyle(.segmented)
-        .labelsHidden()
-        .onChange(of: presetSettings.countdownDisplayMode) { newValue in
-            guard selectedCountdownDisplayMode != newValue else { return }
-            selectedCountdownDisplayMode = newValue
+            .pickerStyle(.segmented)
+            .labelsHidden()
+            .frame(width: 210)
+            .onChange(of: presetSettings.countdownDisplayMode) { newValue in
+                guard selectedCountdownDisplayMode != newValue else { return }
+                selectedCountdownDisplayMode = newValue
+            }
         }
     }
 
     private var alwaysOnTopToggle: some View {
-        Toggle(
-            "Always on top",
-            isOn: Binding(
-                get: { presetSettings.alwaysOnTop },
-                set: { presetSettings.setAlwaysOnTop($0) }
+        settingRow("Always on top", description: "Keep the companion above other windows.") {
+            Toggle(
+                "Always on top",
+                isOn: Binding(
+                    get: { presetSettings.alwaysOnTop },
+                    set: { presetSettings.setAlwaysOnTop($0) }
+                )
             )
-        )
-        .font(.caption)
+            .labelsHidden()
+            .toggleStyle(.switch)
+        }
     }
 
     private var showBelowNotchToggle: some View {
-        Toggle(
-            "Show below notch",
-            isOn: Binding(
-                get: { presetSettings.showBelowNotch },
-                set: { presetSettings.setShowBelowNotch($0) }
+        settingRow("Position", description: "Place the companion below the physical notch.") {
+            Toggle(
+                "Show below notch",
+                isOn: Binding(
+                    get: { presetSettings.showBelowNotch },
+                    set: { presetSettings.setShowBelowNotch($0) }
+                )
             )
-        )
-        .font(.caption)
+            .labelsHidden()
+            .toggleStyle(.switch)
+        }
     }
 
     private var autoStartNextIntervalToggle: some View {
-        Toggle(
-            "Auto-start next interval (10s delay)",
-            isOn: Binding(
-                get: { presetSettings.autoStartNextInterval },
-                set: { presetSettings.setAutoStartNextInterval($0) }
+        settingRow(
+            "Auto-start next interval",
+            description: "Start the next focus or break interval after 10 seconds."
+        ) {
+            Toggle(
+                "Auto-start next interval",
+                isOn: Binding(
+                    get: { presetSettings.autoStartNextInterval },
+                    set: { presetSettings.setAutoStartNextInterval($0) }
+                )
             )
-        )
-        .font(.caption)
+            .labelsHidden()
+            .toggleStyle(.switch)
+        }
     }
 
     private var hasNotchedScreen: Bool {
@@ -307,152 +453,12 @@ private extension SettingsMenuView {
             + "-\(PresetSettingsStore.maxRoundsBeforeLongBreak)"
         return "Valid range: Focus \(focusRange) min, Break \(breakRange) min, Long cycle \(cycleRange) sessions"
     }
+}
 
-    // MARK: - Keyboard Settings
-
-    var keyboardSettingsSection: some View {
-        VStack(alignment: .leading, spacing: 8) {
-            Toggle(
-                "Enable keyboard shortcuts",
-                isOn: Binding(
-                    get: { localKeyboardConfig.enabled },
-                    set: { newValue in
-                        var updated = localKeyboardConfig
-                        updated.enabled = newValue
-                        localKeyboardConfig = updated
-                        keyboardShortcutService.updateConfig(updated)
-                    }
-                )
-            )
-            .font(.caption)
-            .help("Space to start/pause, Escape to reset. Works when Oak is active.")
-
-            if localKeyboardConfig.enabled {
-                VStack(alignment: .leading, spacing: 4) {
-                    let toggleShortcut = localKeyboardConfig.shortcuts[.toggleSession]
-                        ?? KeyboardShortcutAction.toggleSession.defaultKey
-                    shortcutRow(action: .toggleSession, shortcut: toggleShortcut)
-                    let resetShortcut = localKeyboardConfig.shortcuts[.resetSession]
-                        ?? KeyboardShortcutAction.resetSession.defaultKey
-                    shortcutRow(action: .resetSession, shortcut: resetShortcut)
-                }
-                .padding(.leading, 16)
-
-                Toggle(
-                    "Enable global hotkeys",
-                    isOn: Binding(
-                        get: { localKeyboardConfig.globalHotkeysEnabled },
-                        set: { newValue in
-                            var updated = localKeyboardConfig
-                            updated.globalHotkeysEnabled = newValue
-                            localKeyboardConfig = updated
-                            keyboardShortcutService.updateConfig(updated)
-                        }
-                    )
-                )
-                .font(.caption)
-                .help("Requires Accessibility permission in System Settings.")
-            }
-        }
-    }
-
-    private func shortcutRow(action: KeyboardShortcutAction, shortcut: KeyEquivalent) -> some View {
-        HStack(spacing: 8) {
-            Text(shortcut.displayString)
-                .font(.caption.monospaced())
-                .foregroundColor(palette.secondaryForeground)
-                .padding(.horizontal, 4)
-                .padding(.vertical, 2)
-                .background(palette.controlBackground)
-                .cornerRadius(4)
-            Text(action.displayName)
-                .font(.caption)
-            Spacer()
-        }
-    }
-
-    // MARK: - Data Export / Import
-
-    var dataSection: some View {
-        VStack(alignment: .leading, spacing: 8) {
-            Text("Back up or restore your progress data.")
-                .font(.caption)
-                .foregroundColor(palette.secondaryForeground)
-
-            HStack(spacing: 8) {
-                Button("Export JSON") {
-                    exportJSON()
-                }
-                .buttonStyle(.bordered)
-                .controlSize(.small)
-                .disabled(progressManager == nil)
-
-                Button("Export CSV") {
-                    exportCSV()
-                }
-                .buttonStyle(.bordered)
-                .controlSize(.small)
-                .disabled(progressManager == nil)
-
-                Button("Import") {
-                    importData()
-                }
-                .buttonStyle(.bordered)
-                .controlSize(.small)
-                .disabled(progressManager == nil)
-            }
-        }
-    }
-
-    private func exportJSON() {
-        guard let manager = progressManager,
-              let data = manager.exportJSON()
-        else { return }
-        let panel = NSSavePanel()
-        panel.nameFieldStringValue = "oak-progress-\(dateStamp()).json"
-        panel.allowedContentTypes = [.json]
-        panel.begin { response in
-            if response == .OK, let url = panel.url {
-                try? data.write(to: url)
-            }
-        }
-    }
-
-    private func exportCSV() {
-        guard let manager = progressManager else { return }
-        let csv = manager.exportCSV()
-        let panel = NSSavePanel()
-        panel.nameFieldStringValue = "oak-progress-\(dateStamp()).csv"
-        panel.allowedContentTypes = [.commaSeparatedText]
-        panel.begin { response in
-            if response == .OK, let url = panel.url {
-                try? csv.write(to: url, atomically: true, encoding: .utf8)
-            }
-        }
-    }
-
-    private func importData() {
-        guard let manager = progressManager else { return }
-        let panel = NSOpenPanel()
-        panel.allowedContentTypes = [.json]
-        panel.begin { response in
-            if response == .OK, let url = panel.url, let data = try? Data(contentsOf: url) {
-                let count = manager.importRecords(from: data)
-                if count > 0 {
-                    DispatchQueue.main.async {
-                        let alert = NSAlert()
-                        alert.messageText = "Import complete"
-                        alert.informativeText = "Imported \(count) day(s) of progress data."
-                        alert.runModal()
-                    }
-                }
-            }
-        }
-    }
-
-    private func dateStamp() -> String {
-        let formatter = DateFormatter()
-        formatter.dateFormat = "yyyy-MM-dd"
-        return formatter.string(from: Date())
-    }
+private enum SettingsTab: Hashable {
+    case general
+    case sessions
+    case notifications
+    case shortcuts
+    case advanced
 }

--- a/Oak/Oak/Views/SettingsVersion.swift
+++ b/Oak/Oak/Views/SettingsVersion.swift
@@ -1,0 +1,23 @@
+import Foundation
+
+internal enum SettingsVersion {
+    internal static var current: String {
+        let fallbackBundle = Bundle(identifier: "com.productsway.oak.app")
+            ?? Bundle(for: FocusSessionViewModel.self)
+
+        if let version = version(in: Bundle.main) ?? version(in: fallbackBundle) {
+            return "v\(version.short) (\(version.build))"
+        }
+
+        return "v0.0.0 (0)"
+    }
+
+    private static func version(in bundle: Bundle) -> (short: String, build: String)? {
+        guard let short = bundle.infoDictionary?["CFBundleShortVersionString"] as? String,
+              let build = bundle.infoDictionary?["CFBundleVersion"] as? String
+        else {
+            return nil
+        }
+        return (short, build)
+    }
+}

--- a/Oak/Oak/Views/SettingsWindowLayout.swift
+++ b/Oak/Oak/Views/SettingsWindowLayout.swift
@@ -22,6 +22,16 @@ internal enum SettingsTab: String, CaseIterable, Identifiable {
         }
     }
 
+    internal var symbolName: String {
+        switch self {
+        case .general: "gearshape"
+        case .sessions: "timer"
+        case .notifications: "bell"
+        case .shortcuts: "keyboard"
+        case .advanced: "slider.horizontal.3"
+        }
+    }
+
     internal var accessibilityIdentifier: String {
         "settingsTab_\(rawValue)"
     }
@@ -88,8 +98,11 @@ internal struct SettingsSegmentedControl: NSViewRepresentable {
     }
 
     internal static func makeControl(target: AnyObject?, action: Selector?) -> NSSegmentedControl {
+        let images = SettingsTab.allCases.map { tab in
+            NSImage(systemSymbolName: tab.symbolName, accessibilityDescription: tab.title)!
+        }
         let control = NSSegmentedControl(
-            labels: SettingsTab.allCases.map(\.title),
+            images: images,
             trackingMode: .selectOne,
             target: target,
             action: action
@@ -102,6 +115,7 @@ internal struct SettingsSegmentedControl: NSViewRepresentable {
 
         for (index, tab) in SettingsTab.allCases.enumerated() {
             control.setWidth(0, forSegment: index)
+            control.setImageScaling(.scaleProportionallyDown, forSegment: index)
             control.setToolTip(tab.title, forSegment: index)
         }
         return control

--- a/Oak/Oak/Views/SettingsWindowLayout.swift
+++ b/Oak/Oak/Views/SettingsWindowLayout.swift
@@ -1,4 +1,3 @@
-import AppKit
 import SwiftUI
 
 internal enum SettingsTab: String, CaseIterable, Identifiable {
@@ -40,6 +39,8 @@ internal enum SettingsTab: String, CaseIterable, Identifiable {
 internal struct SettingsTabNavigation: View {
     @Binding internal var selectedTab: SettingsTab
     internal let theme: AppTheme
+    @FocusState private var focusedTab: SettingsTab?
+    @State private var hoveredTab: SettingsTab?
 
     private var palette: ThemePalette {
         theme.palette
@@ -51,107 +52,125 @@ internal struct SettingsTabNavigation: View {
     }
 
     internal var body: some View {
-        SettingsSegmentedControl(selectedTab: $selectedTab, theme: theme)
-            .frame(height: 28)
-            .frame(maxWidth: .infinity)
-            .padding(.horizontal, SettingsWindowLayout.navigationHorizontalPadding)
-            .padding(.vertical, 12)
-            .background(palette.surface)
-            .accessibilityIdentifier("settingsTabBar")
+        HStack(spacing: SettingsWindowLayout.tabSpacing) {
+            ForEach(SettingsTab.allCases) { tab in
+                Button {
+                    selectedTab = tab
+                } label: {
+                    Image(systemName: tab.symbolName)
+                        .accessibilityHidden(true)
+                }
+                .buttonStyle(
+                    SettingsTabButtonStyle(
+                        isSelected: selectedTab == tab,
+                        isHovered: hoveredTab == tab,
+                        isFocused: focusedTab == tab,
+                        palette: palette
+                    )
+                )
+                .focused($focusedTab, equals: tab)
+                .help(tab.title)
+                .accessibilityLabel(Text(tab.title))
+                .accessibilityValue(selectedTab == tab ? "Selected" : "")
+                .accessibilityIdentifier(tab.accessibilityIdentifier)
+                .onHover { isHovered in
+                    if isHovered {
+                        hoveredTab = tab
+                    } else if hoveredTab == tab {
+                        hoveredTab = nil
+                    }
+                }
+            }
+        }
+        .padding(SettingsWindowLayout.tabContainerPadding)
+        .background(palette.controlBackground)
+        .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
+        .onMoveCommand(perform: moveSelection)
+        .frame(maxWidth: .infinity)
+        .padding(.horizontal, SettingsWindowLayout.navigationHorizontalPadding)
+        .padding(.vertical, 12)
+        .background(palette.surface)
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel("Settings sections")
+        .accessibilityIdentifier("settingsTabBar")
+    }
+
+    private func moveSelection(_ direction: MoveCommandDirection) {
+        guard let currentIndex = SettingsTab.allCases.firstIndex(of: focusedTab ?? selectedTab) else { return }
+        let nextIndex: Int
+        switch direction {
+        case .left:
+            nextIndex = max(currentIndex - 1, SettingsTab.allCases.startIndex)
+        case .right:
+            nextIndex = min(currentIndex + 1, SettingsTab.allCases.index(before: SettingsTab.allCases.endIndex))
+        default:
+            return
+        }
+        let nextTab = SettingsTab.allCases[nextIndex]
+        selectedTab = nextTab
+        focusedTab = nextTab
     }
 }
 
-internal struct SettingsSegmentedControl: NSViewRepresentable {
-    @Binding internal var selectedTab: SettingsTab
-    internal let theme: AppTheme
+internal struct SettingsTabButtonStyle: ButtonStyle {
+    internal let isSelected: Bool
+    internal let isHovered: Bool
+    internal let isFocused: Bool
+    internal let palette: ThemePalette
 
-    internal init(selectedTab: Binding<SettingsTab>, theme: AppTheme) {
-        _selectedTab = selectedTab
-        self.theme = theme
+    internal func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .font(.system(size: 14, weight: isSelected ? .semibold : .regular))
+            .foregroundStyle(isSelected ? palette.prominentSelectedForeground : palette.foreground)
+            .frame(maxWidth: .infinity, minHeight: SettingsWindowLayout.tabHeight)
+            .background {
+                RoundedRectangle(cornerRadius: 6, style: .continuous)
+                    .fill(isSelected ? palette.prominentSelectedBackground : .clear)
+            }
+            .overlay {
+                RoundedRectangle(cornerRadius: 6, style: .continuous)
+                    .strokeBorder(stateOutlineColor, lineWidth: stateOutlineWidth)
+            }
+            .contentShape(Rectangle())
+            // Geometry gives press feedback without weakening icon contrast.
+            .scaleEffect(configuration.isPressed ? 0.96 : 1)
     }
 
-    internal func makeCoordinator() -> Coordinator {
-        Coordinator(parent: self)
-    }
-
-    internal func makeNSView(context: Context) -> NSSegmentedControl {
-        let control = Self.makeControl(
-            target: context.coordinator,
-            action: #selector(Coordinator.selectionChanged(_:))
-        )
-        update(control)
-        return control
-    }
-
-    internal func updateNSView(_ control: NSSegmentedControl, context: Context) {
-        context.coordinator.parent = self
-        update(control)
-    }
-
-    internal func sizeThatFits(
-        _ proposal: ProposedViewSize,
-        nsView _: NSSegmentedControl,
-        context _: Context
-    ) -> CGSize? {
-        guard let width = proposal.width else { return nil }
-        return CGSize(width: width, height: 28)
-    }
-
-    internal static func makeControl(target: AnyObject?, action: Selector?) -> NSSegmentedControl {
-        let images = SettingsTab.allCases.map { tab in
-            NSImage(systemSymbolName: tab.symbolName, accessibilityDescription: tab.title)!
+    private var stateOutlineColor: Color {
+        if isSelected {
+            return palette.prominentSelectedForeground
         }
-        let control = NSSegmentedControl(
-            images: images,
-            trackingMode: .selectOne,
-            target: target,
-            action: action
-        )
-        control.segmentDistribution = .fillEqually
-        control.segmentStyle = .rounded
-        control.setAccessibilityLabel("Settings section")
-        control.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
-        control.setContentHuggingPriority(.defaultLow, for: .horizontal)
-
-        for (index, tab) in SettingsTab.allCases.enumerated() {
-            control.setWidth(0, forSegment: index)
-            control.setImageScaling(.scaleProportionallyDown, forSegment: index)
-            control.setToolTip(tab.title, forSegment: index)
-        }
-        return control
+        return palette.accent
     }
 
-    private func update(_ control: NSSegmentedControl) {
-        control.selectedSegment = SettingsTab.allCases.firstIndex(of: selectedTab) ?? 0
-        control.selectedSegmentBezelColor = NSColor(theme.palette.accent)
-    }
-
-    @MainActor
-    internal final class Coordinator: NSObject {
-        internal var parent: SettingsSegmentedControl
-
-        internal init(parent: SettingsSegmentedControl) {
-            self.parent = parent
+    private var stateOutlineWidth: CGFloat {
+        if isFocused {
+            return 2
         }
-
-        @objc internal func selectionChanged(_ control: NSSegmentedControl) {
-            guard SettingsTab.allCases.indices.contains(control.selectedSegment) else { return }
-            parent.selectedTab = SettingsTab.allCases[control.selectedSegment]
-        }
+        return isHovered ? 1 : 0
     }
 }
 
 internal enum SettingsWindowLayout {
     internal static let navigationHorizontalPadding: CGFloat = 20
-    internal static let minimumTabSegmentWidth: CGFloat = 104
-    internal static let minimumWidth = navigationHorizontalPadding * 2
-        + minimumTabSegmentWidth * CGFloat(SettingsTab.allCases.count)
+    internal static let minimumContentWidth: CGFloat = 520
+    internal static let tabSpacing: CGFloat = 4
+    internal static let tabContainerPadding: CGFloat = 3
+    internal static let tabHeight: CGFloat = 28
+    internal static let minimumWidth = navigationHorizontalPadding * 2 + minimumContentWidth
     internal static let idealWidth: CGFloat = 600
     internal static let minimumHeight: CGFloat = 360
     internal static let maximumHeight: CGFloat = 760
     internal static let fallbackScreenHeight: CGFloat = 900
     internal static let initialPageHeight: CGFloat = 500
     internal static let initialNavigationHeight: CGFloat = 52
+
+    internal static func tabItemWidth(containerWidth: CGFloat) -> CGFloat {
+        let navigationWidth = max(containerWidth - navigationHorizontalPadding * 2, 0)
+        let itemWidth = navigationWidth - tabContainerPadding * 2
+            - tabSpacing * CGFloat(SettingsTab.allCases.count - 1)
+        return max(itemWidth / CGFloat(SettingsTab.allCases.count), 0)
+    }
 
     internal static func windowHeight(
         pageContentHeight: CGFloat,

--- a/Oak/Oak/Views/SettingsWindowLayout.swift
+++ b/Oak/Oak/Views/SettingsWindowLayout.swift
@@ -1,3 +1,4 @@
+import AppKit
 import SwiftUI
 
 internal enum SettingsTab: String, CaseIterable, Identifiable {
@@ -40,26 +41,97 @@ internal struct SettingsTabNavigation: View {
     }
 
     internal var body: some View {
-        Picker("Settings section", selection: $selectedTab) {
-            ForEach(SettingsTab.allCases) { tab in
-                Text(tab.title)
-                    .tag(tab)
-                    .accessibilityIdentifier(tab.accessibilityIdentifier)
-            }
+        SettingsSegmentedControl(selectedTab: $selectedTab, theme: theme)
+            .frame(height: 28)
+            .frame(maxWidth: .infinity)
+            .padding(.horizontal, SettingsWindowLayout.navigationHorizontalPadding)
+            .padding(.vertical, 12)
+            .background(palette.surface)
+            .accessibilityIdentifier("settingsTabBar")
+    }
+}
+
+internal struct SettingsSegmentedControl: NSViewRepresentable {
+    @Binding internal var selectedTab: SettingsTab
+    internal let theme: AppTheme
+
+    internal init(selectedTab: Binding<SettingsTab>, theme: AppTheme) {
+        _selectedTab = selectedTab
+        self.theme = theme
+    }
+
+    internal func makeCoordinator() -> Coordinator {
+        Coordinator(parent: self)
+    }
+
+    internal func makeNSView(context: Context) -> NSSegmentedControl {
+        let control = Self.makeControl(
+            target: context.coordinator,
+            action: #selector(Coordinator.selectionChanged(_:))
+        )
+        update(control)
+        return control
+    }
+
+    internal func updateNSView(_ control: NSSegmentedControl, context: Context) {
+        context.coordinator.parent = self
+        update(control)
+    }
+
+    internal func sizeThatFits(
+        _ proposal: ProposedViewSize,
+        nsView _: NSSegmentedControl,
+        context _: Context
+    ) -> CGSize? {
+        guard let width = proposal.width else { return nil }
+        return CGSize(width: width, height: 28)
+    }
+
+    internal static func makeControl(target: AnyObject?, action: Selector?) -> NSSegmentedControl {
+        let control = NSSegmentedControl(
+            labels: SettingsTab.allCases.map(\.title),
+            trackingMode: .selectOne,
+            target: target,
+            action: action
+        )
+        control.segmentDistribution = .fillEqually
+        control.segmentStyle = .rounded
+        control.setAccessibilityLabel("Settings section")
+        control.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+        control.setContentHuggingPriority(.defaultLow, for: .horizontal)
+
+        for (index, tab) in SettingsTab.allCases.enumerated() {
+            control.setWidth(0, forSegment: index)
+            control.setToolTip(tab.title, forSegment: index)
         }
-        .labelsHidden()
-        .pickerStyle(.segmented)
-        .controlSize(.large)
-        .frame(maxWidth: .infinity)
-        .padding(.horizontal, 20)
-        .padding(.vertical, 12)
-        .background(palette.surface)
-        .accessibilityIdentifier("settingsTabBar")
+        return control
+    }
+
+    private func update(_ control: NSSegmentedControl) {
+        control.selectedSegment = SettingsTab.allCases.firstIndex(of: selectedTab) ?? 0
+        control.selectedSegmentBezelColor = NSColor(theme.palette.accent)
+    }
+
+    @MainActor
+    internal final class Coordinator: NSObject {
+        internal var parent: SettingsSegmentedControl
+
+        internal init(parent: SettingsSegmentedControl) {
+            self.parent = parent
+        }
+
+        @objc internal func selectionChanged(_ control: NSSegmentedControl) {
+            guard SettingsTab.allCases.indices.contains(control.selectedSegment) else { return }
+            parent.selectedTab = SettingsTab.allCases[control.selectedSegment]
+        }
     }
 }
 
 internal enum SettingsWindowLayout {
-    internal static let minimumWidth: CGFloat = 560
+    internal static let navigationHorizontalPadding: CGFloat = 20
+    internal static let minimumTabSegmentWidth: CGFloat = 104
+    internal static let minimumWidth = navigationHorizontalPadding * 2
+        + minimumTabSegmentWidth * CGFloat(SettingsTab.allCases.count)
     internal static let idealWidth: CGFloat = 600
     internal static let minimumHeight: CGFloat = 360
     internal static let maximumHeight: CGFloat = 760

--- a/Oak/Oak/Views/SettingsWindowLayout.swift
+++ b/Oak/Oak/Views/SettingsWindowLayout.swift
@@ -71,7 +71,7 @@ internal struct SettingsTabNavigation: View {
                 .focused($focusedTab, equals: tab)
                 .help(tab.title)
                 .accessibilityLabel(Text(tab.title))
-                .accessibilityValue(selectedTab == tab ? "Selected" : "")
+                .accessibilityAddTraits(selectedTab == tab ? .isSelected : [])
                 .accessibilityIdentifier(tab.accessibilityIdentifier)
                 .onHover { isHovered in
                     if isHovered {

--- a/Oak/Oak/Views/SettingsWindowLayout.swift
+++ b/Oak/Oak/Views/SettingsWindowLayout.swift
@@ -1,0 +1,99 @@
+import SwiftUI
+
+internal enum SettingsTab: String, CaseIterable, Identifiable {
+    case general
+    case sessions
+    case notifications
+    case shortcuts
+    case advanced
+
+    internal var id: String {
+        rawValue
+    }
+
+    internal var title: String {
+        switch self {
+        case .general: "General"
+        case .sessions: "Sessions"
+        case .notifications: "Notifications"
+        case .shortcuts: "Shortcuts"
+        case .advanced: "Advanced"
+        }
+    }
+
+    internal var accessibilityIdentifier: String {
+        "settingsTab_\(rawValue)"
+    }
+}
+
+internal struct SettingsTabNavigation: View {
+    @Binding internal var selectedTab: SettingsTab
+    internal let theme: AppTheme
+
+    private var palette: ThemePalette {
+        theme.palette
+    }
+
+    internal init(selectedTab: Binding<SettingsTab>, theme: AppTheme) {
+        _selectedTab = selectedTab
+        self.theme = theme
+    }
+
+    internal var body: some View {
+        Picker("Settings section", selection: $selectedTab) {
+            ForEach(SettingsTab.allCases) { tab in
+                Text(tab.title)
+                    .tag(tab)
+                    .accessibilityIdentifier(tab.accessibilityIdentifier)
+            }
+        }
+        .labelsHidden()
+        .pickerStyle(.segmented)
+        .controlSize(.large)
+        .frame(maxWidth: .infinity)
+        .padding(.horizontal, 20)
+        .padding(.vertical, 12)
+        .background(palette.surface)
+        .accessibilityIdentifier("settingsTabBar")
+    }
+}
+
+internal enum SettingsWindowLayout {
+    internal static let minimumWidth: CGFloat = 560
+    internal static let idealWidth: CGFloat = 600
+    internal static let minimumHeight: CGFloat = 360
+    internal static let maximumHeight: CGFloat = 760
+    internal static let fallbackScreenHeight: CGFloat = 900
+    internal static let initialPageHeight: CGFloat = 500
+    internal static let initialNavigationHeight: CGFloat = 52
+
+    internal static func windowHeight(
+        pageContentHeight: CGFloat,
+        navigationHeight: CGFloat,
+        screenHeight: CGFloat
+    ) -> CGFloat {
+        let screenBound = min(maximumHeight, screenHeight * 0.85)
+        let maximum = max(minimumHeight, screenBound)
+        return min(max(pageContentHeight + navigationHeight + 1, minimumHeight), maximum)
+    }
+
+    internal static func pageViewportHeight(windowHeight: CGFloat, navigationHeight: CGFloat) -> CGFloat {
+        max(windowHeight - navigationHeight - 1, 0)
+    }
+}
+
+internal struct SettingsPageHeightPreferenceKey: PreferenceKey {
+    internal static let defaultValue: CGFloat = 0
+
+    internal static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
+        value = max(value, nextValue())
+    }
+}
+
+internal struct SettingsNavigationHeightPreferenceKey: PreferenceKey {
+    internal static let defaultValue: CGFloat = SettingsWindowLayout.initialNavigationHeight
+
+    internal static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
+        value = max(value, nextValue())
+    }
+}

--- a/Oak/Oak/Views/SupportSectionView.swift
+++ b/Oak/Oak/Views/SupportSectionView.swift
@@ -5,19 +5,29 @@ internal struct SupportSectionView: View {
 
     private var palette: ThemePalette { theme.palette }
 
-    var body: some View {
+    internal var body: some View {
         VStack(alignment: .leading, spacing: 8) {
             Text("If Oak helps you focus, consider supporting the project ⭐️")
                 .font(.caption)
                 .foregroundColor(palette.secondaryForeground)
 
-            HStack(spacing: 12) {
-                Link("⭐ Star on GitHub", destination: URL(string: "https://github.com/jellydn/oak")!)
-                Link("☕ Buy Me a Coffee", destination: URL(string: "https://www.buymeacoffee.com/dunghd")!)
-                Link("❤️ Ko-fi", destination: URL(string: "https://ko-fi.com/dunghd")!)
-                Link("💙 PayPal", destination: URL(string: "https://paypal.me/dunghd")!)
+            ViewThatFits(in: .horizontal) {
+                HStack(spacing: 12) {
+                    supportLinks
+                }
+
+                VStack(alignment: .leading, spacing: 8) {
+                    supportLinks
+                }
             }
-            .font(.caption)
         }
+    }
+
+    @ViewBuilder
+    private var supportLinks: some View {
+        Link("Star on GitHub", destination: URL(string: "https://github.com/jellydn/oak")!)
+        Link("Buy Me a Coffee", destination: URL(string: "https://www.buymeacoffee.com/dunghd")!)
+        Link("Ko-fi", destination: URL(string: "https://ko-fi.com/dunghd")!)
+        Link("PayPal", destination: URL(string: "https://paypal.me/dunghd")!)
     }
 }

--- a/Oak/Oak/Views/SupportSectionView.swift
+++ b/Oak/Oak/Views/SupportSectionView.swift
@@ -3,7 +3,9 @@ import SwiftUI
 internal struct SupportSectionView: View {
     internal let theme: AppTheme
 
-    private var palette: ThemePalette { theme.palette }
+    private var palette: ThemePalette {
+        theme.palette
+    }
 
     internal var body: some View {
         VStack(alignment: .leading, spacing: 8) {

--- a/Oak/Oak/Views/SupportSectionView.swift
+++ b/Oak/Oak/Views/SupportSectionView.swift
@@ -1,11 +1,15 @@
 import SwiftUI
 
 internal struct SupportSectionView: View {
+    var theme: AppTheme = .oak
+
+    private var palette: ThemePalette { theme.palette }
+
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
             Text("If Oak helps you focus, consider supporting the project ⭐️")
                 .font(.caption)
-                .foregroundColor(.secondary)
+                .foregroundColor(palette.secondaryForeground)
 
             HStack(spacing: 12) {
                 Link("⭐ Star on GitHub", destination: URL(string: "https://github.com/jellydn/oak")!)

--- a/Oak/Oak/Views/SupportSectionView.swift
+++ b/Oak/Oak/Views/SupportSectionView.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
 internal struct SupportSectionView: View {
-    var theme: AppTheme = .oak
+    internal let theme: AppTheme
 
     private var palette: ThemePalette { theme.palette }
 

--- a/Oak/Oak/Views/UpdateSettingsView.swift
+++ b/Oak/Oak/Views/UpdateSettingsView.swift
@@ -2,7 +2,7 @@ import SwiftUI
 
 internal struct UpdateSettingsView: View {
     @ObservedObject var sparkleUpdater: SparkleUpdater
-    var theme: AppTheme = .oak
+    internal let theme: AppTheme
 
     private var palette: ThemePalette { theme.palette }
 

--- a/Oak/Oak/Views/UpdateSettingsView.swift
+++ b/Oak/Oak/Views/UpdateSettingsView.swift
@@ -2,13 +2,16 @@ import SwiftUI
 
 internal struct UpdateSettingsView: View {
     @ObservedObject var sparkleUpdater: SparkleUpdater
+    var theme: AppTheme = .oak
+
+    private var palette: ThemePalette { theme.palette }
 
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
             if !sparkleUpdater.isConfigured {
                 Text("Update signing is not configured (missing SUPublicEDKey).")
                     .font(.caption)
-                    .foregroundColor(.secondary)
+                    .foregroundColor(palette.secondaryForeground)
             }
 
             Toggle(

--- a/Oak/Oak/Views/UpdateSettingsView.swift
+++ b/Oak/Oak/Views/UpdateSettingsView.swift
@@ -4,7 +4,9 @@ internal struct UpdateSettingsView: View {
     @ObservedObject internal var sparkleUpdater: SparkleUpdater
     internal let theme: AppTheme
 
-    private var palette: ThemePalette { theme.palette }
+    private var palette: ThemePalette {
+        theme.palette
+    }
 
     internal var body: some View {
         VStack(alignment: .leading, spacing: 12) {

--- a/Oak/Oak/Views/UpdateSettingsView.swift
+++ b/Oak/Oak/Views/UpdateSettingsView.swift
@@ -1,44 +1,54 @@
 import SwiftUI
 
 internal struct UpdateSettingsView: View {
-    @ObservedObject var sparkleUpdater: SparkleUpdater
+    @ObservedObject internal var sparkleUpdater: SparkleUpdater
     internal let theme: AppTheme
 
     private var palette: ThemePalette { theme.palette }
 
-    var body: some View {
-        VStack(alignment: .leading, spacing: 8) {
+    internal var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
             if !sparkleUpdater.isConfigured {
                 Text("Update signing is not configured (missing SUPublicEDKey).")
                     .font(.caption)
                     .foregroundColor(palette.secondaryForeground)
             }
 
-            Toggle(
+            updateToggle(
                 "Automatically check for updates",
                 isOn: Binding(
                     get: { sparkleUpdater.automaticallyChecksForUpdates },
                     set: { sparkleUpdater.setAutomaticallyChecksForUpdates($0) }
                 )
             )
-            .font(.caption)
             .disabled(!sparkleUpdater.isConfigured)
 
-            Toggle(
+            updateToggle(
                 "Automatically download updates",
                 isOn: Binding(
                     get: { sparkleUpdater.automaticallyDownloadsUpdates },
                     set: { sparkleUpdater.setAutomaticallyDownloadsUpdates($0) }
                 )
             )
-            .font(.caption)
             .disabled(!sparkleUpdater.isConfigured || !sparkleUpdater.automaticallyChecksForUpdates)
 
             Button("Check for Updates Now") {
                 sparkleUpdater.checkForUpdates()
             }
-            .buttonStyle(.link)
+            .buttonStyle(.bordered)
             .disabled(!sparkleUpdater.isConfigured || !sparkleUpdater.canCheckForUpdates)
+        }
+    }
+
+    private func updateToggle(_ title: String, isOn: Binding<Bool>) -> some View {
+        HStack(spacing: 16) {
+            Text(title)
+
+            Spacer(minLength: 12)
+
+            Toggle(title, isOn: isOn)
+                .labelsHidden()
+                .toggleStyle(.switch)
         }
     }
 }

--- a/Oak/Tests/OakTests/AccessibilityTests.swift
+++ b/Oak/Tests/OakTests/AccessibilityTests.swift
@@ -192,6 +192,7 @@ internal final class AccessibilityTests: XCTestCase {
             "autoStartCountdown",
             "presetToggleButton",
             "themePicker",
+            "settingsTabBar",
             "settingsTab_general",
             "settingsTab_sessions",
             "settingsTab_notifications",
@@ -205,5 +206,57 @@ internal final class AccessibilityTests: XCTestCase {
             uniqueIdentifiers.count,
             "All accessibility identifiers should be unique"
         )
+    }
+
+    internal func testSettingsWindowHeightFitsShortContent() {
+        let height = SettingsWindowLayout.windowHeight(
+            pageContentHeight: 180,
+            navigationHeight: 52,
+            screenHeight: 900
+        )
+
+        XCTAssertEqual(height, SettingsWindowLayout.minimumHeight)
+    }
+
+    internal func testSettingsWindowHeightTracksActiveTabContent() {
+        let height = SettingsWindowLayout.windowHeight(
+            pageContentHeight: 430,
+            navigationHeight: 52,
+            screenHeight: 900
+        )
+
+        XCTAssertEqual(height, 483)
+    }
+
+    internal func testSettingsWindowHeightBoundsLargeAccessibilityContent() {
+        let height = SettingsWindowLayout.windowHeight(
+            pageContentHeight: 1200,
+            navigationHeight: 80,
+            screenHeight: 700
+        )
+
+        XCTAssertEqual(height, 595)
+        XCTAssertEqual(
+            SettingsWindowLayout.pageViewportHeight(windowHeight: height, navigationHeight: 80),
+            514
+        )
+    }
+
+    internal func testSettingsTabNavigationHasStableLabelsAndMinimumWidth() {
+        XCTAssertEqual(
+            SettingsTab.allCases.map(\.title),
+            ["General", "Sessions", "Notifications", "Shortcuts", "Advanced"]
+        )
+        XCTAssertEqual(
+            SettingsTab.allCases.map(\.accessibilityIdentifier),
+            [
+                "settingsTab_general",
+                "settingsTab_sessions",
+                "settingsTab_notifications",
+                "settingsTab_shortcuts",
+                "settingsTab_advanced"
+            ]
+        )
+        XCTAssertGreaterThanOrEqual(SettingsWindowLayout.minimumWidth, 560)
     }
 }

--- a/Oak/Tests/OakTests/AccessibilityTests.swift
+++ b/Oak/Tests/OakTests/AccessibilityTests.swift
@@ -257,6 +257,10 @@ internal final class AccessibilityTests: XCTestCase {
                 "settingsTab_advanced"
             ]
         )
+        XCTAssertEqual(
+            SettingsTab.allCases.map(\.symbolName),
+            ["gearshape", "timer", "bell", "keyboard", "slider.horizontal.3"]
+        )
         XCTAssertGreaterThanOrEqual(SettingsWindowLayout.minimumWidth, 560)
     }
 
@@ -266,7 +270,13 @@ internal final class AccessibilityTests: XCTestCase {
         XCTAssertEqual(control.segmentCount, 5)
         XCTAssertEqual(control.segmentDistribution, .fillEqually)
         XCTAssertEqual(
-            (0 ..< control.segmentCount).compactMap { control.label(forSegment: $0) },
+            (0 ..< control.segmentCount).compactMap {
+                control.image(forSegment: $0)?.accessibilityDescription
+            },
+            SettingsTab.allCases.map(\.title)
+        )
+        XCTAssertEqual(
+            (0 ..< control.segmentCount).compactMap { control.toolTip(forSegment: $0) },
             SettingsTab.allCases.map(\.title)
         )
         let minimumSegmentWidth = (SettingsWindowLayout.minimumWidth

--- a/Oak/Tests/OakTests/AccessibilityTests.swift
+++ b/Oak/Tests/OakTests/AccessibilityTests.swift
@@ -191,7 +191,12 @@ internal final class AccessibilityTests: XCTestCase {
             "countdownDisplay",
             "autoStartCountdown",
             "presetToggleButton",
-            "themePicker"
+            "themePicker",
+            "settingsTab_general",
+            "settingsTab_sessions",
+            "settingsTab_notifications",
+            "settingsTab_shortcuts",
+            "settingsTab_advanced"
         ]
 
         let uniqueIdentifiers = Set(identifiers)

--- a/Oak/Tests/OakTests/AccessibilityTests.swift
+++ b/Oak/Tests/OakTests/AccessibilityTests.swift
@@ -190,7 +190,8 @@ internal final class AccessibilityTests: XCTestCase {
             "startNextButton",
             "countdownDisplay",
             "autoStartCountdown",
-            "presetToggleButton"
+            "presetToggleButton",
+            "themePicker"
         ]
 
         let uniqueIdentifiers = Set(identifiers)

--- a/Oak/Tests/OakTests/AccessibilityTests.swift
+++ b/Oak/Tests/OakTests/AccessibilityTests.swift
@@ -264,28 +264,18 @@ internal final class AccessibilityTests: XCTestCase {
         XCTAssertGreaterThanOrEqual(SettingsWindowLayout.minimumWidth, 560)
     }
 
-    internal func testSettingsTabControlUsesFiveEqualSegments() {
-        let control = SettingsSegmentedControl.makeControl(target: nil, action: nil)
-
-        XCTAssertEqual(control.segmentCount, 5)
-        XCTAssertEqual(control.segmentDistribution, .fillEqually)
+    internal func testSettingsTabNavigationDividesConstrainedWidthsEqually() {
+        XCTAssertEqual(SettingsTab.allCases.count, 5)
+        XCTAssertEqual(SettingsWindowLayout.tabItemWidth(containerWidth: 400), 67.6, accuracy: 0.001)
         XCTAssertEqual(
-            (0 ..< control.segmentCount).compactMap {
-                control.image(forSegment: $0)?.accessibilityDescription
-            },
-            SettingsTab.allCases.map(\.title)
+            SettingsWindowLayout.tabItemWidth(containerWidth: SettingsWindowLayout.minimumWidth),
+            99.6,
+            accuracy: 0.001
         )
         XCTAssertEqual(
-            (0 ..< control.segmentCount).compactMap { control.toolTip(forSegment: $0) },
-            SettingsTab.allCases.map(\.title)
+            SettingsWindowLayout.tabItemWidth(containerWidth: SettingsWindowLayout.idealWidth),
+            107.6,
+            accuracy: 0.001
         )
-        let minimumSegmentWidth = (SettingsWindowLayout.minimumWidth
-            - SettingsWindowLayout.navigationHorizontalPadding * 2)
-            / CGFloat(control.segmentCount)
-        let normalSegmentWidth = (SettingsWindowLayout.idealWidth
-            - SettingsWindowLayout.navigationHorizontalPadding * 2)
-            / CGFloat(control.segmentCount)
-        XCTAssertEqual(minimumSegmentWidth, SettingsWindowLayout.minimumTabSegmentWidth)
-        XCTAssertEqual(normalSegmentWidth, 112)
     }
 }

--- a/Oak/Tests/OakTests/AccessibilityTests.swift
+++ b/Oak/Tests/OakTests/AccessibilityTests.swift
@@ -259,4 +259,23 @@ internal final class AccessibilityTests: XCTestCase {
         )
         XCTAssertGreaterThanOrEqual(SettingsWindowLayout.minimumWidth, 560)
     }
+
+    internal func testSettingsTabControlUsesFiveEqualSegments() {
+        let control = SettingsSegmentedControl.makeControl(target: nil, action: nil)
+
+        XCTAssertEqual(control.segmentCount, 5)
+        XCTAssertEqual(control.segmentDistribution, .fillEqually)
+        XCTAssertEqual(
+            (0 ..< control.segmentCount).compactMap { control.label(forSegment: $0) },
+            SettingsTab.allCases.map(\.title)
+        )
+        let minimumSegmentWidth = (SettingsWindowLayout.minimumWidth
+            - SettingsWindowLayout.navigationHorizontalPadding * 2)
+            / CGFloat(control.segmentCount)
+        let normalSegmentWidth = (SettingsWindowLayout.idealWidth
+            - SettingsWindowLayout.navigationHorizontalPadding * 2)
+            / CGFloat(control.segmentCount)
+        XCTAssertEqual(minimumSegmentWidth, SettingsWindowLayout.minimumTabSegmentWidth)
+        XCTAssertEqual(normalSegmentWidth, 112)
+    }
 }

--- a/Oak/Tests/OakTests/ThemeTests.swift
+++ b/Oak/Tests/OakTests/ThemeTests.swift
@@ -116,7 +116,7 @@ internal final class ThemeTests: XCTestCase {
         }
     }
 
-    func testProminentSelectionColorsMeetNonTextContrast() throws {
+    internal func testProminentSelectionColorsMeetNonTextContrast() throws {
         for theme in AppTheme.allCases {
             let palette = theme.palette
 

--- a/Oak/Tests/OakTests/ThemeTests.swift
+++ b/Oak/Tests/OakTests/ThemeTests.swift
@@ -26,25 +26,48 @@ internal final class ThemeTests: XCTestCase {
     }
 
     func testThemeChoicesHaveStableNames() {
-        XCTAssertEqual(AppTheme.allCases.map(\.displayName), ["Oak", "Kanagawa", "Dracula", "Tokyo Night"])
+        XCTAssertEqual(
+            AppTheme.allCases.map(\.displayName),
+            [
+                "Oak",
+                "Kanagawa",
+                "Kanagawa Lotus",
+                "Dracula",
+                "Alucard (Dracula Light)",
+                "Tokyo Night",
+                "Tokyo Night Day"
+            ]
+        )
     }
 
     func testThemeDefaultsToOak() {
         XCTAssertEqual(presetSettings.theme, .oak)
     }
 
-    func testNamedThemesUseCanonicalCoreColors() throws {
+    func testNamedThemesUseDocumentedCoreColors() throws {
         try assertColor(.kanagawa, background: 0x1F1F28, foreground: 0xDCD7BA, accent: 0x7E9CD8)
+        try assertColor(.kanagawaLotus, background: 0xF2ECBC, foreground: 0x43436C, accent: 0x4D699B)
         try assertColor(.dracula, background: 0x282A36, foreground: 0xF8F8F2, accent: 0x8BE9FD)
+        try assertColor(.alucard, background: 0xFFFBEB, foreground: 0x1F1F1F, accent: 0x036A96)
         try assertColor(.tokyoNight, background: 0x222436, foreground: 0xC8D3F5, accent: 0x82AAFF)
+        try assertColor(.tokyoNightDay, background: 0xE1E2E7, foreground: 0x2E5857, accent: 0x006A83)
     }
 
-    func testSelectedThemePersists() {
-        presetSettings.setTheme(.kanagawa)
+    func testEachSelectedThemePersists() {
+        for theme in AppTheme.allCases {
+            presetSettings.setTheme(theme)
 
-        let reloadedSettings = PresetSettingsStore(userDefaults: userDefaults)
+            let reloadedSettings = PresetSettingsStore(userDefaults: userDefaults)
 
-        XCTAssertEqual(reloadedSettings.theme, .kanagawa)
+            XCTAssertEqual(reloadedSettings.theme, theme)
+        }
+    }
+
+    func testThemeColorSchemesMatchTheirVariants() {
+        XCTAssertEqual(
+            AppTheme.allCases.filter { $0.palette.colorScheme == .light },
+            [.kanagawaLotus, .alucard, .tokyoNightDay]
+        )
     }
 
     func testUnknownPersistedThemeFallsBackToOak() {
@@ -66,33 +89,29 @@ internal final class ThemeTests: XCTestCase {
     func testThemeTextMeetsWCAGAAContrast() throws {
         for theme in AppTheme.allCases {
             let palette = theme.palette
-            XCTAssertGreaterThanOrEqual(
-                try contrastRatio(palette.foreground, over: palette.background),
-                4.5,
-                "\(theme.displayName) primary text must meet WCAG AA"
-            )
-            XCTAssertGreaterThanOrEqual(
-                try contrastRatio(palette.secondaryForeground, over: palette.background),
-                4.5,
-                "\(theme.displayName) secondary text must meet WCAG AA"
-            )
-            XCTAssertGreaterThanOrEqual(
-                try contrastRatio(palette.subtleForeground, over: palette.background),
-                4.5,
-                "\(theme.displayName) subtle text must meet WCAG AA"
-            )
+            for background in [palette.background, palette.surface] {
+                for color in [palette.foreground, palette.secondaryForeground, palette.subtleForeground] {
+                    XCTAssertGreaterThanOrEqual(
+                        try contrastRatio(color, over: background),
+                        4.5,
+                        "\(theme.displayName) text must meet WCAG AA on each app background"
+                    )
+                }
+            }
         }
     }
 
     func testThemeActionColorsMeetNonTextContrast() throws {
         for theme in AppTheme.allCases {
             let palette = theme.palette
-            for color in [palette.accent, palette.success, palette.warning, palette.error] {
-                XCTAssertGreaterThanOrEqual(
-                    try contrastRatio(color, over: palette.background),
-                    3,
-                    "\(theme.displayName) action colors must remain visible on the app background"
-                )
+            for background in [palette.background, palette.surface] {
+                for color in [palette.accent, palette.success, palette.warning, palette.error] {
+                    XCTAssertGreaterThanOrEqual(
+                        try contrastRatio(color, over: background),
+                        3,
+                        "\(theme.displayName) action colors must remain visible on each app background"
+                    )
+                }
             }
         }
     }

--- a/Oak/Tests/OakTests/ThemeTests.swift
+++ b/Oak/Tests/OakTests/ThemeTests.swift
@@ -44,7 +44,7 @@ internal final class ThemeTests: XCTestCase {
         XCTAssertEqual(presetSettings.theme, .oak)
     }
 
-    func testNamedThemesUseDocumentedCoreColors() throws {
+    internal func testNamedThemesUseDocumentedCoreColors() throws {
         try assertColor(.kanagawa, background: 0x1F1F28, foreground: 0xDCD7BA, accent: 0x7E9CD8)
         try assertColor(.kanagawaLotus, background: 0xF2ECBC, foreground: 0x43436C, accent: 0x4D699B)
         try assertColor(.dracula, background: 0x282A36, foreground: 0xF8F8F2, accent: 0x8BE9FD)
@@ -53,7 +53,7 @@ internal final class ThemeTests: XCTestCase {
         try assertColor(.tokyoNightDay, background: 0xE1E2E7, foreground: 0x2E5857, accent: 0x006A83)
     }
 
-    func testEachSelectedThemePersists() {
+    internal func testEachSelectedThemePersists() {
         for theme in AppTheme.allCases {
             presetSettings.setTheme(theme)
 
@@ -63,7 +63,7 @@ internal final class ThemeTests: XCTestCase {
         }
     }
 
-    func testThemeColorSchemesMatchTheirVariants() {
+    internal func testThemeColorSchemesMatchTheirVariants() {
         XCTAssertEqual(
             AppTheme.allCases.filter { $0.palette.colorScheme == .light },
             [.kanagawaLotus, .alucard, .tokyoNightDay]

--- a/Oak/Tests/OakTests/ThemeTests.swift
+++ b/Oak/Tests/OakTests/ThemeTests.swift
@@ -116,6 +116,26 @@ internal final class ThemeTests: XCTestCase {
         }
     }
 
+    func testProminentSelectionColorsMeetNonTextContrast() throws {
+        for theme in AppTheme.allCases {
+            let palette = theme.palette
+
+            XCTAssertGreaterThanOrEqual(
+                try contrastRatio(
+                    palette.prominentSelectedForeground,
+                    over: palette.prominentSelectedBackground
+                ),
+                3,
+                "\(theme.displayName) prominent selection must keep its icon visible"
+            )
+            XCTAssertGreaterThanOrEqual(
+                try contrastRatio(palette.foreground, over: palette.surface),
+                4.5,
+                "\(theme.displayName) unselected navigation icons must remain readable"
+            )
+        }
+    }
+
     private func contrastRatio(_ foreground: Color, over background: Color) throws -> Double {
         let foregroundComponents = try colorComponents(foreground)
         let backgroundComponents = try colorComponents(background)

--- a/Oak/Tests/OakTests/ThemeTests.swift
+++ b/Oak/Tests/OakTests/ThemeTests.swift
@@ -1,0 +1,165 @@
+import AppKit
+import SwiftUI
+import XCTest
+@testable import Oak
+
+@MainActor
+internal final class ThemeTests: XCTestCase {
+    private var suiteName: String!
+    private var userDefaults: UserDefaults!
+    private var presetSettings: PresetSettingsStore!
+
+    override func setUp() async throws {
+        suiteName = "OakTests.ThemeTests.\(UUID().uuidString)"
+        guard let defaults = UserDefaults(suiteName: suiteName) else {
+            throw NSError(domain: "ThemeTests", code: 1)
+        }
+        defaults.removePersistentDomain(forName: suiteName)
+        userDefaults = defaults
+        presetSettings = PresetSettingsStore(userDefaults: defaults)
+    }
+
+    override func tearDown() async throws {
+        UserDefaults(suiteName: suiteName)?.removePersistentDomain(forName: suiteName)
+        presetSettings = nil
+        userDefaults = nil
+    }
+
+    func testThemeChoicesHaveStableNames() {
+        XCTAssertEqual(AppTheme.allCases.map(\.displayName), ["Oak", "Kanagawa", "Dracula", "Tokyo Night"])
+    }
+
+    func testThemeDefaultsToOak() {
+        XCTAssertEqual(presetSettings.theme, .oak)
+    }
+
+    func testNamedThemesUseCanonicalCoreColors() throws {
+        try assertColor(.kanagawa, background: 0x1F1F28, foreground: 0xDCD7BA, accent: 0x7E9CD8)
+        try assertColor(.dracula, background: 0x282A36, foreground: 0xF8F8F2, accent: 0x8BE9FD)
+        try assertColor(.tokyoNight, background: 0x222436, foreground: 0xC8D3F5, accent: 0x82AAFF)
+    }
+
+    func testSelectedThemePersists() {
+        presetSettings.setTheme(.kanagawa)
+
+        let reloadedSettings = PresetSettingsStore(userDefaults: userDefaults)
+
+        XCTAssertEqual(reloadedSettings.theme, .kanagawa)
+    }
+
+    func testUnknownPersistedThemeFallsBackToOak() {
+        userDefaults.set("removed-theme", forKey: "appearance.theme")
+
+        let reloadedSettings = PresetSettingsStore(userDefaults: userDefaults)
+
+        XCTAssertEqual(reloadedSettings.theme, .oak)
+    }
+
+    func testResetRestoresOakTheme() {
+        presetSettings.setTheme(.dracula)
+
+        presetSettings.resetToDefault()
+
+        XCTAssertEqual(presetSettings.theme, .oak)
+    }
+
+    func testThemeTextMeetsWCAGAAContrast() throws {
+        for theme in AppTheme.allCases {
+            let palette = theme.palette
+            XCTAssertGreaterThanOrEqual(
+                try contrastRatio(palette.foreground, over: palette.background),
+                4.5,
+                "\(theme.displayName) primary text must meet WCAG AA"
+            )
+            XCTAssertGreaterThanOrEqual(
+                try contrastRatio(palette.secondaryForeground, over: palette.background),
+                4.5,
+                "\(theme.displayName) secondary text must meet WCAG AA"
+            )
+            XCTAssertGreaterThanOrEqual(
+                try contrastRatio(palette.subtleForeground, over: palette.background),
+                4.5,
+                "\(theme.displayName) subtle text must meet WCAG AA"
+            )
+        }
+    }
+
+    func testThemeActionColorsMeetNonTextContrast() throws {
+        for theme in AppTheme.allCases {
+            let palette = theme.palette
+            for color in [palette.accent, palette.success, palette.warning, palette.error] {
+                XCTAssertGreaterThanOrEqual(
+                    try contrastRatio(color, over: palette.background),
+                    3,
+                    "\(theme.displayName) action colors must remain visible on the app background"
+                )
+            }
+        }
+    }
+
+    private func contrastRatio(_ foreground: Color, over background: Color) throws -> Double {
+        let foregroundComponents = try colorComponents(foreground)
+        let backgroundComponents = try colorComponents(background)
+        let compositedForeground = RGBComponents(
+            red: foregroundComponents.red * foregroundComponents.alpha
+                + backgroundComponents.red * (1 - foregroundComponents.alpha),
+            green: foregroundComponents.green * foregroundComponents.alpha
+                + backgroundComponents.green * (1 - foregroundComponents.alpha),
+            blue: foregroundComponents.blue * foregroundComponents.alpha
+                + backgroundComponents.blue * (1 - foregroundComponents.alpha),
+            alpha: 1
+        )
+        let lighter = max(relativeLuminance(compositedForeground), relativeLuminance(backgroundComponents))
+        let darker = min(relativeLuminance(compositedForeground), relativeLuminance(backgroundComponents))
+        return (lighter + 0.05) / (darker + 0.05)
+    }
+
+    private func assertColor(
+        _ theme: AppTheme,
+        background: UInt32,
+        foreground: UInt32,
+        accent: UInt32
+    ) throws {
+        try assertColor(theme.palette.background, equals: background)
+        try assertColor(theme.palette.foreground, equals: foreground)
+        try assertColor(theme.palette.accent, equals: accent)
+    }
+
+    private func assertColor(_ color: Color, equals hex: UInt32) throws {
+        let components = try colorComponents(color)
+        XCTAssertEqual(components.red, Double((hex >> 16) & 0xFF) / 255, accuracy: 0.001)
+        XCTAssertEqual(components.green, Double((hex >> 8) & 0xFF) / 255, accuracy: 0.001)
+        XCTAssertEqual(components.blue, Double(hex & 0xFF) / 255, accuracy: 0.001)
+    }
+
+    private func colorComponents(_ color: Color) throws -> RGBComponents {
+        guard let convertedColor = NSColor(color).usingColorSpace(.sRGB) else {
+            throw NSError(domain: "ThemeTests", code: 2)
+        }
+        return RGBComponents(
+            red: Double(convertedColor.redComponent),
+            green: Double(convertedColor.greenComponent),
+            blue: Double(convertedColor.blueComponent),
+            alpha: Double(convertedColor.alphaComponent)
+        )
+    }
+
+    private func relativeLuminance(_ components: RGBComponents) -> Double {
+        0.2126 * linearized(components.red)
+            + 0.7152 * linearized(components.green)
+            + 0.0722 * linearized(components.blue)
+    }
+
+    private func linearized(_ component: Double) -> Double {
+        component <= 0.04045
+            ? component / 12.92
+            : pow((component + 0.055) / 1.055, 2.4)
+    }
+}
+
+private struct RGBComponents {
+    let red: Double
+    let green: Double
+    let blue: Double
+    let alpha: Double
+}

--- a/README.md
+++ b/README.md
@@ -53,8 +53,17 @@ In today's world of constant distractions, deep work has become increasingly rar
 - 📊 **Local tracking**: Track daily focus minutes, completed sessions, and 7-day streaks
 - 🕒 **Session timeline**: See each focus session and break from today with start/end times and durations
 - 💾 **Data export**: Export your progress as JSON or CSV, or import from a backup file
-- 🎨 **Themes**: Choose Oak, Kanagawa, Dracula, or Tokyo Night in Settings
+- 🎨 **Themes**: Choose Oak, Kanagawa, Dracula, Tokyo Night, or their light variants in Settings
 - 🔄 **Auto-update**: Seamless updates via Sparkle framework
+
+### Theme palettes
+
+Oak follows the official [Kanagawa Wave and Lotus](https://github.com/rebelot/kanagawa.nvim),
+[Dracula and Alucard](https://github.com/dracula/dracula-theme), and
+[Tokyo Night Moon and Day](https://github.com/folke/tokyonight.nvim) palettes. Alucard is Dracula's official
+open-source light counterpart, so Oak labels it “Alucard (Dracula Light).” Where an editor token has insufficient
+contrast in Oak's compact controls, Oak uses a stronger token from the same palette. Dracula's error red is minimally
+brightened because its canonical red does not reach 3:1 against the canonical current-line surface.
 
 ### Finding sounds to import
 

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ In today's world of constant distractions, deep work has become increasingly rar
 - 📊 **Local tracking**: Track daily focus minutes, completed sessions, and 7-day streaks
 - 🕒 **Session timeline**: See each focus session and break from today with start/end times and durations
 - 💾 **Data export**: Export your progress as JSON or CSV, or import from a backup file
+- 🎨 **Themes**: Choose Oak, Kanagawa, Dracula, or Tokyo Night in Settings
 - 🔄 **Auto-update**: Seamless updates via Sparkle framework
 
 ### Finding sounds to import

--- a/docs/index.html
+++ b/docs/index.html
@@ -521,7 +521,7 @@ brew install --cask oak</code></pre>
                 </article>
                 <article class="card">
                     <h3>Selectable themes</h3>
-                    <p>Choose Oak, Kanagawa, Dracula, or Tokyo Night colors across the companion and its menus.</p>
+                    <p>Choose Oak, Kanagawa, Dracula, Tokyo Night, or their light variants across the app.</p>
                 </article>
                 <article class="card">
                     <h3>Local progress tracking</h3>

--- a/docs/index.html
+++ b/docs/index.html
@@ -520,6 +520,10 @@ brew install --cask oak</code></pre>
                     <p>Rain, forest, cafe, brown noise, and lo-fi tracks are built in.</p>
                 </article>
                 <article class="card">
+                    <h3>Selectable themes</h3>
+                    <p>Choose Oak, Kanagawa, Dracula, or Tokyo Night colors across the companion and its menus.</p>
+                </article>
+                <article class="card">
                     <h3>Local progress tracking</h3>
                     <p>Track daily focus minutes, completed sessions, and 7-day streaks entirely on-device.</p>
                 </article>


### PR DESCRIPTION
## What

- Add seven selectable themes: Oak, Kanagawa Wave, Kanagawa Lotus, Dracula, Alucard (Dracula Light), Tokyo Night Moon, and Tokyo Night Day
- Persist the selected theme and apply semantic theme colors across the app
- Redesign Settings into General, Sessions, Notifications, Shortcuts, and Advanced tabs
- Improve setting groups, labels, spacing, control alignment, and narrow-window layouts
- Add persistence, canonical palette, contrast, and accessibility coverage

## Why

Oak had one fixed dark appearance and hard-coded colors across several views. The original settings pane also put every option in one dense column, which made related controls difficult to scan and compare.

## How

- Model themes as an `AppTheme` enum backed by semantic `ThemePalette` tokens
- Use the official Kanagawa Wave/Lotus, Dracula/Alucard, and Tokyo Night Moon/Day families; Alucard is the official Dracula light counterpart
- Use stronger tokens from the same source palette where an editor token does not meet Oak's compact-control contrast requirements
- Reuse `PresetSettingsStore` and `UserDefaults` for reactive app-wide selection and persistence
- Keep Oak as the default and preserve its near-black notch appearance
- Verify text against WCAG AA and action colors against 3:1 non-text contrast thresholds on both background and surface tokens
- Compose Settings from scrollable tab pages, semantic cards, aligned rows, focused preset/notification panels, and `ViewThatFits` fallbacks

## Checklist

- [x] Tests added or updated
- [x] Documentation updated
- [x] Strict SwiftLint passes
- [x] macOS build and test pass
- [x] PR remains draft and unmerged


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added seven selectable themes, including light variants, across the app.
  * Added dedicated settings tabs for General, Sessions, Notifications, Shortcuts, and Advanced.
  * Added keyboard shortcut configuration and progress data export/import tools.
* **Improvements**
  * Applied theme-aware styling throughout the app.
  * Improved responsive settings navigation, window sizing, support links, preset editing, and notification actions.
  * Added keyboard navigation and clearer settings controls.
* **Documentation**
  * Documented available themes and added a selectable themes feature to the documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->